### PR TITLE
Using boost to calculate hash for function signature

### DIFF
--- a/ci/travis_install_toolchain.sh
+++ b/ci/travis_install_toolchain.sh
@@ -28,7 +28,8 @@ if [ ! -e $CPP_TOOLCHAIN ]; then
         cmake \
         curl \
         ninja \
-        arrow-cpp
+        arrow-cpp \
+        boost-cpp
 
     conda update -y -q -p $CPP_TOOLCHAIN ca-certificates -c defaults
 fi

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -12,11 +12,12 @@ Build Gandiva requires:
 * LLVM 
 * Arrow
 * GTest
+* Boost
 
 On OS X, you can use [Homebrew][1]:
 
 ```shell
-brew install cmake llvm
+brew install cmake llvm boost
 ```
 
 ## Building Gandiva

--- a/cpp/src/gandiva/CMakeLists.txt
+++ b/cpp/src/gandiva/CMakeLists.txt
@@ -32,6 +32,9 @@ include_directories(${ARROW_INCLUDE_DIR})
 find_package(GTest REQUIRED)
 include_directories(${GTEST_INCLUDE_DIRS})
 
+find_package(Boost REQUIRED)
+include_directories(${Boost_INCLUDE_DIRS})
+
 include_directories(.)
 include_directories(codegen)
 include_directories(codegen/cex)

--- a/cpp/src/gandiva/codegen/function_signature.h
+++ b/cpp/src/gandiva/codegen/function_signature.h
@@ -21,6 +21,7 @@
 #include <vector>
 #include "common/arrow.h"
 #include "common/logging.h"
+#include "boost/container_hash/hash.hpp"
 
 namespace gandiva {
 
@@ -58,16 +59,16 @@ class FunctionSignature {
     return true;
   }
 
-  /// includes only the id of the datatype.
+  /// calculated based on base_name, datatpype id of parameters and datatype id
+  /// of return type.
   std::size_t Hash() const {
     static const size_t kSeedValue = 17;
-    static const size_t kHashMultiplier = 31;
-
     size_t result = kSeedValue;
-    result = result * kHashMultiplier + std::hash<std::string>()(base_name_);
-    result = result * kHashMultiplier + std::hash<int>()(ret_type_->id());
+    boost::hash_combine(result, base_name_);
+    boost::hash_combine(result, ret_type_->id());
+    /// not using hash_range since we only want to include the id from the data type
     for (auto it = param_types_.begin(); it != param_types_.end(); it++) {
-      result = result * kHashMultiplier + std::hash<int>()(it->get()->id());
+      boost::hash_combine(result, it->get()->id());
     }
     return result;
   }


### PR DESCRIPTION
Changing from manually calculating hash for function signature to using boost functions to do the same.

Introduces a dependency on boost across the board.

Resolves : GDV-50.