### PR TITLE
Fix destructor and add include_directories

### DIFF
--- a/cpp/cmake/FindARROW.cmake
+++ b/cpp/cmake/FindARROW.cmake
@@ -18,6 +18,7 @@ find_library(ARROW_LIB arrow REQUIRED)
 message(STATUS "Found arrow library at ${ARROW_LIB}")
 
 find_path(ARROW_INCLUDE_DIR arrow/type.h)
+include_directories("${ARROW_INCLUDE_DIR}")
 message(STATUS "found arrow includes at ${ARROW_INCLUDE_DIR}")
 
 # add an imported target ARROW::ARROW so that gandiva can take a dependency.

--- a/cpp/src/codegen/node.h
+++ b/cpp/src/codegen/node.h
@@ -34,6 +34,8 @@ class Node {
   explicit Node(DataTypePtr return_type)
     : return_type_(return_type) { }
 
+  virtual ~Node() = default;
+
   const DataTypePtr &return_type() const { return return_type_; }
 
   /// Derived classes should simply invoke the Visit api of the visitor.


### PR DESCRIPTION
This PR fixes a memory leak where destruction of pointers to `Node`s that are
instances of child classes are not called because `Node`'s destructor is not
virtual.