### PR TITLE
GDV-90:[C++]Fixed extract second from time.

### DIFF
--- a/cpp/src/precompiled/time.cc
+++ b/cpp/src/precompiled/time.cc
@@ -14,6 +14,7 @@
 
 extern "C" {
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
 
@@ -23,6 +24,7 @@ extern "C" {
 #define MILLIS_TO_MINS(millis) ((millis) / (60 * 1000))
 #define MILLIS_TO_HOUR(millis) ((millis) / (60 * 60 * 1000))
 #define MINS_IN_HOUR 60
+#define SECONDS_IN_MINUTE 60
 
 // Expand inner macro for all date types.
 #define DATE_TYPES(INNER) \
@@ -375,9 +377,13 @@ DATE_TYPES(EXTRACT_SECOND)
 DATE_TYPES(EXTRACT_EPOCH)
 
 // Functions that work on millis in a day
-#define EXTRACT_SECOND_TIME(TYPE) \
-  FORCE_INLINE                    \
-  int64 extractSecond##_##TYPE(TYPE millis) { return MILLIS_TO_SEC(millis); }
+#define EXTRACT_SECOND_TIME(TYPE)                   \
+  FORCE_INLINE                                      \
+  int64 extractSecond##_##TYPE(TYPE millis) {       \
+    int64 seconds_of_day = MILLIS_TO_SEC(millis);   \
+    int64 sec = seconds_of_day % SECONDS_IN_MINUTE; \
+    return sec;                                     \
+  }
 
 EXTRACT_SECOND_TIME(time32)
 

--- a/cpp/src/precompiled/time.cc
+++ b/cpp/src/precompiled/time.cc
@@ -14,7 +14,6 @@
 
 extern "C" {
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
 

--- a/cpp/src/precompiled/time_test.cc
+++ b/cpp/src/precompiled/time_test.cc
@@ -25,6 +25,15 @@ timestamp StringToTimestamp(const char *buf) {
   return timegm(&tm) * 1000;  // to millis
 }
 
+TEST(TestTime, TestExtractTime) {
+  // 10:20:33
+  int32 time_as_millis_in_day = 37233000;
+
+  EXPECT_EQ(extractHour_time32(time_as_millis_in_day), 10);
+  EXPECT_EQ(extractMinute_time32(time_as_millis_in_day), 20);
+  EXPECT_EQ(extractSecond_time32(time_as_millis_in_day), 33);
+}
+
 TEST(TestTime, TestExtractTimestamp) {
   timestamp ts = StringToTimestamp("1970-05-02 10:20:33");
 

--- a/cpp/src/precompiled/types.h
+++ b/cpp/src/precompiled/types.h
@@ -64,6 +64,10 @@ int64 extractHour_timestamp(timestamp millis);
 int64 extractMinute_timestamp(timestamp millis);
 int64 extractSecond_timestamp(timestamp millis);
 
+int64 extractHour_time32(int32 millis_in_day);
+int64 extractMinute_time32(int32 millis_in_day);
+int64 extractSecond_time32(int32 millis_in_day);
+
 int32 mem_compare(const char *left, int32 left_len, const char *right, int32 right_len);
 
 }  // extern "C"


### PR DESCRIPTION
Fixed the implementation of extract second from time.