### PR TITLE
GDV-31:[C++]Avoid gmtime_r due to perf issues.

### DIFF
--- a/cpp/cmake/BuildUtils.cmake
+++ b/cpp/cmake/BuildUtils.cmake
@@ -84,6 +84,7 @@ function(add_precompiled_unit_test REL_TEST_NAME)
 
   add_executable(${TEST_NAME} ${REL_TEST_NAME} ${ARGN})
   target_include_directories(${TEST_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/src)
+  target_include_directories(${TEST_NAME} PRIVATE $<TARGET_PROPERTY:Boost::boost,INTERFACE_INCLUDE_DIRECTORIES>)
   target_link_libraries(${TEST_NAME} PRIVATE gtest_main)
   target_compile_definitions(${TEST_NAME} PRIVATE GANDIVA_UNIT_TEST=1)
   add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})

--- a/cpp/cmake/FindLLVM.cmake
+++ b/cpp/cmake/FindLLVM.cmake
@@ -27,7 +27,7 @@ message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 # Find the libraries that correspond to the LLVM components
 llvm_map_components_to_libnames(LLVM_LIBS core mcjit native ipo bitreader target linker analysis debuginfodwarf)
 
-set(CLANG_EXECUTABLE ${LLVM_TOOLS_BINARY_DIR}/clang CACHE STRING "clang")
+set(CLANG_EXECUTABLE ${LLVM_TOOLS_BINARY_DIR}/clang++ CACHE STRING "clang")
 set(LINK_EXECUTABLE ${LLVM_TOOLS_BINARY_DIR}/llvm-link CACHE STRING "link")
 set(CLANG_FORMAT_EXECUTABLE ${LLVM_TOOLS_BINARY_DIR}/clang-format CACHE STRING "clang-format")
 

--- a/cpp/src/CMakeLists.txt
+++ b/cpp/src/CMakeLists.txt
@@ -19,6 +19,10 @@ project(gandiva)
 # LLVM/Clang is required by multiple subdirs.
 find_package(LLVM)
 
+# Boost is required by multiple subdirs
+find_package(Boost COMPONENTS system regex filesystem REQUIRED)
+
+
 # Set the path where the byte-code files will be installed.
 set(GANDIVA_BC_FILE_NAME irhelpers.bc)
 set(GANDIVA_BC_INSTALL_DIR

--- a/cpp/src/codegen/CMakeLists.txt
+++ b/cpp/src/codegen/CMakeLists.txt
@@ -17,8 +17,6 @@ project(gandiva)
 # Find arrow
 find_package(ARROW)
 
-find_package(Boost COMPONENTS system regex filesystem REQUIRED)
-
 set(BC_FILE_PATH_CC "${CMAKE_CURRENT_BINARY_DIR}/bc_file_path.cc")
 configure_file(bc_file_path.cc.in ${BC_FILE_PATH_CC})
 

--- a/cpp/src/precompiled/CMakeLists.txt
+++ b/cpp/src/precompiled/CMakeLists.txt
@@ -32,7 +32,7 @@ foreach(SRC_FILE ${PRECOMPILED_SRCS})
   add_custom_command(
     OUTPUT ${BC_FILE}
     COMMAND ${CLANG_EXECUTABLE}
-            -std=c++11 -emit-llvm -O2 -c ${ABSOLUTE_SRC} -o ${BC_FILE}
+            -fno-use-cxa-atexit -std=c++11 -emit-llvm -O2 -c ${ABSOLUTE_SRC} -o ${BC_FILE}
             -I$<TARGET_PROPERTY:Boost::boost,INTERFACE_INCLUDE_DIRECTORIES>
     DEPENDS ${SRC_FILE})
   list(APPEND BC_FILES ${BC_FILE})

--- a/cpp/src/precompiled/CMakeLists.txt
+++ b/cpp/src/precompiled/CMakeLists.txt
@@ -33,6 +33,7 @@ foreach(SRC_FILE ${PRECOMPILED_SRCS})
     OUTPUT ${BC_FILE}
     COMMAND ${CLANG_EXECUTABLE}
             -std=c++11 -emit-llvm -O2 -c ${ABSOLUTE_SRC} -o ${BC_FILE}
+            -I$<TARGET_PROPERTY:Boost::boost,INTERFACE_INCLUDE_DIRECTORIES>
     DEPENDS ${SRC_FILE})
   list(APPEND BC_FILES ${BC_FILE})
 endforeach()

--- a/cpp/src/precompiled/time.cc
+++ b/cpp/src/precompiled/time.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "boost/date_time/posix_time/posix_time.hpp"
+
 extern "C" {
 
 #include <stdlib.h>
@@ -29,82 +31,82 @@ extern "C" {
   INNER(timestamp)
 
 // Extract millennium
-#define EXTRACT_MILLENNIUM(TYPE)                  \
-  FORCE_INLINE                                    \
-  int64 extractMillennium##_##TYPE(TYPE millis) { \
-    time_t tsec = (time_t)MILLIS_TO_SEC(millis);  \
-    struct tm tm;                                 \
-    gmtime_r(&tsec, &tm);                         \
-    return (1900 + tm.tm_year - 1) / 1000 + 1;    \
+#define EXTRACT_MILLENNIUM(TYPE)                                           \
+  FORCE_INLINE                                                             \
+  int64 extractMillennium##_##TYPE(TYPE millis) {                          \
+    time_t tsec = (time_t)MILLIS_TO_SEC(millis);                           \
+    boost::posix_time::ptime ptime = boost::posix_time::from_time_t(tsec); \
+    struct tm time = boost::posix_time::to_tm(ptime);                      \
+    return (1900 + time.tm_year - 1) / 1000 + 1;                           \
   }
 
 DATE_TYPES(EXTRACT_MILLENNIUM)
 
 // Extract century
-#define EXTRACT_CENTURY(TYPE)                    \
-  FORCE_INLINE                                   \
-  int64 extractCentury##_##TYPE(TYPE millis) {   \
-    time_t tsec = (time_t)MILLIS_TO_SEC(millis); \
-    struct tm tm;                                \
-    gmtime_r(&tsec, &tm);                        \
-    return (1900 + tm.tm_year - 1) / 100 + 1;    \
+#define EXTRACT_CENTURY(TYPE)                                              \
+  FORCE_INLINE                                                             \
+  int64 extractCentury##_##TYPE(TYPE millis) {                             \
+    time_t tsec = (time_t)MILLIS_TO_SEC(millis);                           \
+    boost::posix_time::ptime ptime = boost::posix_time::from_time_t(tsec); \
+    struct tm time = boost::posix_time::to_tm(ptime);                      \
+    return (1900 + time.tm_year - 1) / 100 + 1;                            \
   }
 
 DATE_TYPES(EXTRACT_CENTURY)
 
 // Extract  decade
-#define EXTRACT_DECADE(TYPE)                     \
-  FORCE_INLINE                                   \
-  int64 extractDecade##_##TYPE(TYPE millis) {    \
-    time_t tsec = (time_t)MILLIS_TO_SEC(millis); \
-    struct tm tm;                                \
-    gmtime_r(&tsec, &tm);                        \
-    return (1900 + tm.tm_year) / 10;             \
+#define EXTRACT_DECADE(TYPE)                                               \
+  FORCE_INLINE                                                             \
+  int64 extractDecade##_##TYPE(TYPE millis) {                              \
+    time_t tsec = (time_t)MILLIS_TO_SEC(millis);                           \
+    boost::posix_time::ptime ptime = boost::posix_time::from_time_t(tsec); \
+    struct tm time = boost::posix_time::to_tm(ptime);                      \
+    return (1900 + time.tm_year) / 10;                                     \
   }
 
 DATE_TYPES(EXTRACT_DECADE)
 
 // Extract  year.
-#define EXTRACT_YEAR(TYPE)                       \
-  FORCE_INLINE                                   \
-  int64 extractYear##_##TYPE(TYPE millis) {      \
-    time_t tsec = (time_t)MILLIS_TO_SEC(millis); \
-    struct tm tm;                                \
-    gmtime_r(&tsec, &tm);                        \
-    return 1900 + tm.tm_year;                    \
+#define EXTRACT_YEAR(TYPE)                                                 \
+  FORCE_INLINE                                                             \
+  int64 extractYear##_##TYPE(TYPE millis) {                                \
+    time_t tsec = (time_t)MILLIS_TO_SEC(millis);                           \
+    boost::posix_time::ptime ptime = boost::posix_time::from_time_t(tsec); \
+    struct tm time = boost::posix_time::to_tm(ptime);                      \
+    return 1900 + time.tm_year;                                            \
   }
 
 DATE_TYPES(EXTRACT_YEAR)
 
-#define EXTRACT_DOY(TYPE)                        \
-  FORCE_INLINE                                   \
-  int64 extractDoy##_##TYPE(TYPE millis) {       \
-    time_t tsec = (time_t)MILLIS_TO_SEC(millis); \
-    struct tm tm;                                \
-    gmtime_r(&tsec, &tm);                        \
-    return 1 + tm.tm_yday;                       \
+#define EXTRACT_DOY(TYPE)                                                  \
+  FORCE_INLINE                                                             \
+  int64 extractDoy##_##TYPE(TYPE millis) {                                 \
+    time_t tsec = (time_t)MILLIS_TO_SEC(millis);                           \
+    boost::posix_time::ptime ptime = boost::posix_time::from_time_t(tsec); \
+    struct tm time = boost::posix_time::to_tm(ptime);                      \
+    return 1 + time.tm_yday;                                               \
   }
 
 DATE_TYPES(EXTRACT_DOY)
 
-#define EXTRACT_QUARTER(TYPE)                    \
-  FORCE_INLINE                                   \
-  int64 extractQuarter##_##TYPE(TYPE millis) {   \
-    time_t tsec = (time_t)MILLIS_TO_SEC(millis); \
-    struct tm tm;                                \
-    gmtime_r(&tsec, &tm);                        \
-    return tm.tm_mon / 3 + 1;                    \
+#define EXTRACT_QUARTER(TYPE)                                              \
+  FORCE_INLINE                                                             \
+  int64 extractQuarter##_##TYPE(TYPE millis) {                             \
+    time_t tsec = (time_t)MILLIS_TO_SEC(millis);                           \
+    boost::posix_time::ptime ptime = boost::posix_time::from_time_t(tsec); \
+    struct tm time = boost::posix_time::to_tm(ptime);                      \
+    return time.tm_mon / 3 + 1;                                            \
   }
 
 DATE_TYPES(EXTRACT_QUARTER)
 
-#define EXTRACT_MONTH(TYPE)                      \
-  FORCE_INLINE                                   \
-  int64 extractMonth##_##TYPE(TYPE millis) {     \
-    time_t tsec = (time_t)MILLIS_TO_SEC(millis); \
-    struct tm tm;                                \
-    gmtime_r(&tsec, &tm);                        \
-    return 1 + tm.tm_mon;                        \
+#define EXTRACT_MONTH(TYPE)                                                \
+  FORCE_INLINE                                                             \
+  int64 extractMonth##_##TYPE(TYPE millis) {                               \
+    time_t tsec = (time_t)MILLIS_TO_SEC(millis);                           \
+    boost::posix_time::ptime ptime = boost::posix_time::from_time_t(tsec); \
+    struct tm time = boost::posix_time::to_tm(ptime);                      \
+    return 1 + time.tm_mon;                                                \
   }
 
 DATE_TYPES(EXTRACT_MONTH)
@@ -301,68 +303,68 @@ int64 weekOfYear(struct tm *ptm) {
   return weekOfCurrentYear(ptm);
 }
 
-#define EXTRACT_WEEK(TYPE)                       \
-  FORCE_INLINE                                   \
-  int64 extractWeek##_##TYPE(TYPE millis) {      \
-    time_t tsec = (time_t)MILLIS_TO_SEC(millis); \
-    struct tm tm;                                \
-    gmtime_r(&tsec, &tm);                        \
-    return weekOfYear(&tm);                      \
+#define EXTRACT_WEEK(TYPE)                                                 \
+  FORCE_INLINE                                                             \
+  int64 extractWeek##_##TYPE(TYPE millis) {                                \
+    time_t tsec = (time_t)MILLIS_TO_SEC(millis);                           \
+    boost::posix_time::ptime ptime = boost::posix_time::from_time_t(tsec); \
+    struct tm time = boost::posix_time::to_tm(ptime);                      \
+    return weekOfYear(&time);                                              \
   }
 
 DATE_TYPES(EXTRACT_WEEK)
 
-#define EXTRACT_DOW(TYPE)                        \
-  FORCE_INLINE                                   \
-  int64 extractDow##_##TYPE(TYPE millis) {       \
-    time_t tsec = (time_t)MILLIS_TO_SEC(millis); \
-    struct tm tm;                                \
-    gmtime_r(&tsec, &tm);                        \
-    return 1 + tm.tm_wday;                       \
+#define EXTRACT_DOW(TYPE)                                                  \
+  FORCE_INLINE                                                             \
+  int64 extractDow##_##TYPE(TYPE millis) {                                 \
+    time_t tsec = (time_t)MILLIS_TO_SEC(millis);                           \
+    boost::posix_time::ptime ptime = boost::posix_time::from_time_t(tsec); \
+    struct tm time = boost::posix_time::to_tm(ptime);                      \
+    return 1 + time.tm_wday;                                               \
   }
 
 DATE_TYPES(EXTRACT_DOW)
 
-#define EXTRACT_DAY(TYPE)                        \
-  FORCE_INLINE                                   \
-  int64 extractDay##_##TYPE(TYPE millis) {       \
-    time_t tsec = (time_t)MILLIS_TO_SEC(millis); \
-    struct tm tm;                                \
-    gmtime_r(&tsec, &tm);                        \
-    return tm.tm_mday;                           \
+#define EXTRACT_DAY(TYPE)                                                  \
+  FORCE_INLINE                                                             \
+  int64 extractDay##_##TYPE(TYPE millis) {                                 \
+    time_t tsec = (time_t)MILLIS_TO_SEC(millis);                           \
+    boost::posix_time::ptime ptime = boost::posix_time::from_time_t(tsec); \
+    struct tm time = boost::posix_time::to_tm(ptime);                      \
+    return time.tm_mday;                                                   \
   }
 
 DATE_TYPES(EXTRACT_DAY)
 
-#define EXTRACT_HOUR(TYPE)                       \
-  FORCE_INLINE                                   \
-  int64 extractHour##_##TYPE(TYPE millis) {      \
-    time_t tsec = (time_t)MILLIS_TO_SEC(millis); \
-    struct tm tm;                                \
-    gmtime_r(&tsec, &tm);                        \
-    return tm.tm_hour;                           \
+#define EXTRACT_HOUR(TYPE)                                                 \
+  FORCE_INLINE                                                             \
+  int64 extractHour##_##TYPE(TYPE millis) {                                \
+    time_t tsec = (time_t)MILLIS_TO_SEC(millis);                           \
+    boost::posix_time::ptime ptime = boost::posix_time::from_time_t(tsec); \
+    struct tm time = boost::posix_time::to_tm(ptime);                      \
+    return time.tm_hour;                                                   \
   }
 
 DATE_TYPES(EXTRACT_HOUR)
 
-#define EXTRACT_MINUTE(TYPE)                     \
-  FORCE_INLINE                                   \
-  int64 extractMinute##_##TYPE(TYPE millis) {    \
-    time_t tsec = (time_t)MILLIS_TO_SEC(millis); \
-    struct tm tm;                                \
-    gmtime_r(&tsec, &tm);                        \
-    return tm.tm_min;                            \
+#define EXTRACT_MINUTE(TYPE)                                               \
+  FORCE_INLINE                                                             \
+  int64 extractMinute##_##TYPE(TYPE millis) {                              \
+    time_t tsec = (time_t)MILLIS_TO_SEC(millis);                           \
+    boost::posix_time::ptime ptime = boost::posix_time::from_time_t(tsec); \
+    struct tm time = boost::posix_time::to_tm(ptime);                      \
+    return time.tm_min;                                                    \
   }
 
 DATE_TYPES(EXTRACT_MINUTE)
 
-#define EXTRACT_SECOND(TYPE)                     \
-  FORCE_INLINE                                   \
-  int64 extractSecond##_##TYPE(TYPE millis) {    \
-    time_t tsec = (time_t)MILLIS_TO_SEC(millis); \
-    struct tm tm;                                \
-    gmtime_r(&tsec, &tm);                        \
-    return tm.tm_sec;                            \
+#define EXTRACT_SECOND(TYPE)                                               \
+  FORCE_INLINE                                                             \
+  int64 extractSecond##_##TYPE(TYPE millis) {                              \
+    time_t tsec = (time_t)MILLIS_TO_SEC(millis);                           \
+    boost::posix_time::ptime ptime = boost::posix_time::from_time_t(tsec); \
+    struct tm time = boost::posix_time::to_tm(ptime);                      \
+    return time.tm_sec;                                                    \
   }
 
 DATE_TYPES(EXTRACT_SECOND)
@@ -405,54 +407,54 @@ EXTRACT_HOUR_TIME(time32)
     return ((millis / NMILLIS_IN_UNIT) * NMILLIS_IN_UNIT); \
   }
 
-#define DATE_TRUNC_WEEK(TYPE)                    \
-  FORCE_INLINE                                   \
-  TYPE date_trunc_Week_##TYPE(TYPE millis) {     \
-    time_t tsec = (time_t)MILLIS_TO_SEC(millis); \
-    struct tm tm;                                \
-    gmtime_r(&tsec, &tm);                        \
-    tm.tm_sec = 0;                               \
-    tm.tm_min = 0;                               \
-    tm.tm_hour = 0;                              \
-    if (tm.tm_wday == 0) {                       \
-      /* Sunday */                               \
-      tm.tm_mday -= 6;                           \
-    } else {                                     \
-      /* All other days */                       \
-      tm.tm_mday -= (tm.tm_wday - 1);            \
-    }                                            \
-    return (TYPE)timegm(&tm) * MILLIS_IN_SEC;    \
+#define DATE_TRUNC_WEEK(TYPE)                                              \
+  FORCE_INLINE                                                             \
+  TYPE date_trunc_Week_##TYPE(TYPE millis) {                               \
+    time_t tsec = (time_t)MILLIS_TO_SEC(millis);                           \
+    boost::posix_time::ptime ptime = boost::posix_time::from_time_t(tsec); \
+    struct tm tm = boost::posix_time::to_tm(ptime);                        \
+    tm.tm_sec = 0;                                                         \
+    tm.tm_min = 0;                                                         \
+    tm.tm_hour = 0;                                                        \
+    if (tm.tm_wday == 0) {                                                 \
+      /* Sunday */                                                         \
+      tm.tm_mday -= 6;                                                     \
+    } else {                                                               \
+      /* All other days */                                                 \
+      tm.tm_mday -= (tm.tm_wday - 1);                                      \
+    }                                                                      \
+    return (TYPE)timegm(&tm) * MILLIS_IN_SEC;                              \
   }
 
-#define DATE_TRUNC_MONTH_UNITS(NAME, TYPE, NMONTHS_IN_UNIT)      \
-  FORCE_INLINE                                                   \
-  TYPE NAME##_##TYPE(TYPE millis) {                              \
-    time_t tsec = (time_t)MILLIS_TO_SEC(millis);                 \
-    struct tm tm;                                                \
-    gmtime_r(&tsec, &tm);                                        \
-    tm.tm_sec = 0;                                               \
-    tm.tm_min = 0;                                               \
-    tm.tm_hour = 0;                                              \
-    tm.tm_mday = 1;                                              \
-    tm.tm_mon = (tm.tm_mon / NMONTHS_IN_UNIT) * NMONTHS_IN_UNIT; \
-    return (TYPE)timegm(&tm) * MILLIS_IN_SEC;                    \
+#define DATE_TRUNC_MONTH_UNITS(NAME, TYPE, NMONTHS_IN_UNIT)                \
+  FORCE_INLINE                                                             \
+  TYPE NAME##_##TYPE(TYPE millis) {                                        \
+    time_t tsec = (time_t)MILLIS_TO_SEC(millis);                           \
+    boost::posix_time::ptime ptime = boost::posix_time::from_time_t(tsec); \
+    struct tm tm = boost::posix_time::to_tm(ptime);                        \
+    tm.tm_sec = 0;                                                         \
+    tm.tm_min = 0;                                                         \
+    tm.tm_hour = 0;                                                        \
+    tm.tm_mday = 1;                                                        \
+    tm.tm_mon = (tm.tm_mon / NMONTHS_IN_UNIT) * NMONTHS_IN_UNIT;           \
+    return (TYPE)timegm(&tm) * MILLIS_IN_SEC;                              \
   }
 
-#define DATE_TRUNC_YEAR_UNITS(NAME, TYPE, NYEARS_IN_UNIT, OFF_BY)        \
-  FORCE_INLINE                                                           \
-  TYPE NAME##_##TYPE(TYPE millis) {                                      \
-    time_t tsec = (time_t)MILLIS_TO_SEC(millis);                         \
-    struct tm tm;                                                        \
-    gmtime_r(&tsec, &tm);                                                \
-    tm.tm_sec = 0;                                                       \
-    tm.tm_min = 0;                                                       \
-    tm.tm_hour = 0;                                                      \
-    tm.tm_mday = 1;                                                      \
-    tm.tm_mon = 0;                                                       \
-    int year = 1900 + tm.tm_year;                                        \
-    year = ((year - OFF_BY) / NYEARS_IN_UNIT) * NYEARS_IN_UNIT + OFF_BY; \
-    tm.tm_year = year - 1900;                                            \
-    return (TYPE)timegm(&tm) * MILLIS_IN_SEC;                            \
+#define DATE_TRUNC_YEAR_UNITS(NAME, TYPE, NYEARS_IN_UNIT, OFF_BY)          \
+  FORCE_INLINE                                                             \
+  TYPE NAME##_##TYPE(TYPE millis) {                                        \
+    time_t tsec = (time_t)MILLIS_TO_SEC(millis);                           \
+    boost::posix_time::ptime ptime = boost::posix_time::from_time_t(tsec); \
+    struct tm tm = boost::posix_time::to_tm(ptime);                        \
+    tm.tm_sec = 0;                                                         \
+    tm.tm_min = 0;                                                         \
+    tm.tm_hour = 0;                                                        \
+    tm.tm_mday = 1;                                                        \
+    tm.tm_mon = 0;                                                         \
+    int year = 1900 + tm.tm_year;                                          \
+    year = ((year - OFF_BY) / NYEARS_IN_UNIT) * NYEARS_IN_UNIT + OFF_BY;   \
+    tm.tm_year = year - 1900;                                              \
+    return (TYPE)timegm(&tm) * MILLIS_IN_SEC;                              \
   }
 
 #define DATE_TRUNC_FUNCTIONS(TYPE)                              \


### PR DESCRIPTION
gmtime_r uses a global lock leading to spin wait on multithreading.
Using ptime from boost instead.