### PR TITLE
 GDV-118:[CPP]Fix divide by zero errors. 

### DIFF
--- a/cpp/integ/projector_test.cc
+++ b/cpp/integ/projector_test.cc
@@ -554,4 +554,39 @@ TEST_F(TestProjector, TestDivideZero) {
   EXPECT_ARROW_ARRAY_EQUALS(exp_div, outputs.at(0));
 }
 
+TEST_F(TestProjector, TestModZero) {
+  // schema for input fields
+  auto field0 = field("f0", arrow::int64());
+  auto field1 = field("f2", int32());
+  auto schema = arrow::schema({field0, field1});
+
+  // output fields
+  auto field_div = field("mod", int32());
+
+  // Build expression
+  auto mod_expr = TreeExprBuilder::MakeExpression("mod", {field0, field1}, field_div);
+
+  std::shared_ptr<Projector> projector;
+  Status status = Projector::Make(schema, {mod_expr}, &projector);
+  EXPECT_TRUE(status.ok()) << status.message();
+
+  // Create a row-batch with some sample data
+  int num_records = 4;
+  auto array0 = MakeArrowArrayInt64({2, 3, 4, 5}, {true, true, true, true});
+  auto array1 = MakeArrowArrayInt32({1, 2, 2, 0}, {true, true, false, true});
+  // expected output
+  auto exp_mod = MakeArrowArrayInt32({0, 1, 0, 5}, {true, true, false, true});
+
+  // prepare input record batch
+  auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array0, array1});
+
+  // Evaluate expression
+  arrow::ArrayVector outputs;
+  status = projector->Evaluate(*in_batch, pool_, &outputs);
+  EXPECT_TRUE(status.ok()) << status.message();
+
+  // Validate results
+  EXPECT_ARROW_ARRAY_EQUALS(exp_mod, outputs.at(0));
+}
+
 }  // namespace gandiva

--- a/cpp/integ/projector_test.cc
+++ b/cpp/integ/projector_test.cc
@@ -519,4 +519,39 @@ TEST_F(TestProjector, TestZeroCopyNegative) {
   EXPECT_EQ(status.code(), StatusCode::Invalid);
 }
 
+TEST_F(TestProjector, TestDivideZero) {
+  // schema for input fields
+  auto field0 = field("f0", int32());
+  auto field1 = field("f2", int32());
+  auto schema = arrow::schema({field0, field1});
+
+  // output fields
+  auto field_div = field("divide", int32());
+
+  // Build expression
+  auto div_expr = TreeExprBuilder::MakeExpression("divide", {field0, field1}, field_div);
+
+  std::shared_ptr<Projector> projector;
+  Status status = Projector::Make(schema, {div_expr}, &projector);
+  EXPECT_TRUE(status.ok()) << status.message();
+
+  // Create a row-batch with some sample data
+  int num_records = 4;
+  auto array0 = MakeArrowArrayInt32({2, 3, 4, 5}, {true, true, true, true});
+  auto array1 = MakeArrowArrayInt32({1, 2, 2, 0}, {true, true, false, true});
+  // expected output
+  auto exp_div = MakeArrowArrayInt32({2, 1, 0, 0}, {true, true, false, false});
+
+  // prepare input record batch
+  auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array0, array1});
+
+  // Evaluate expression
+  arrow::ArrayVector outputs;
+  status = projector->Evaluate(*in_batch, pool_, &outputs);
+  EXPECT_TRUE(status.ok()) << status.message();
+
+  // Validate results
+  EXPECT_ARROW_ARRAY_EQUALS(exp_div, outputs.at(0));
+}
+
 }  // namespace gandiva

--- a/cpp/src/codegen/function_registry.cc
+++ b/cpp/src/codegen/function_registry.cc
@@ -47,6 +47,16 @@ using std::vector;
                  RESULT_NULL_IF_NULL, STRINGIFY(NAME##_##TYPE##_##TYPE))
 
 // Binary functions that :
+// - have the same input type for both params
+// - output type is same as the input type
+// - NULL handling is of type NULL_INTERNAL
+//
+// The pre-compiled fn name includes the base name & input type names. eg. add_int32_int32
+#define BINARY_SYMMETRIC_SAFE_NULL_INTERNAL(NAME, TYPE)                \
+  NativeFunction(#NAME, DataTypeVector{TYPE(), TYPE()}, TYPE(), true, \
+                 RESULT_NULL_INTERNAL, STRINGIFY(NAME##_##TYPE##_##TYPE))
+
+// Binary functions that :
 // - have different input types, or output type
 // - NULL handling is of type NULL_IF_NULL
 //
@@ -164,7 +174,7 @@ NativeFunction FunctionRegistry::pc_registry_[] = {
     NUMERIC_TYPES(BINARY_SYMMETRIC_SAFE_NULL_IF_NULL, add),
     NUMERIC_TYPES(BINARY_SYMMETRIC_SAFE_NULL_IF_NULL, subtract),
     NUMERIC_TYPES(BINARY_SYMMETRIC_SAFE_NULL_IF_NULL, multiply),
-    NUMERIC_TYPES(BINARY_SYMMETRIC_SAFE_NULL_IF_NULL, divide),
+    NUMERIC_TYPES(BINARY_SYMMETRIC_SAFE_NULL_INTERNAL, divide),
     BINARY_GENERIC_SAFE_NULL_IF_NULL(mod, int64, int32, int32),
     BINARY_GENERIC_SAFE_NULL_IF_NULL(mod, int64, int64, int64),
     NUMERIC_BOOL_DATE_TYPES(BINARY_RELATIONAL_SAFE_NULL_IF_NULL, equal),

--- a/cpp/src/codegen/function_registry.cc
+++ b/cpp/src/codegen/function_registry.cc
@@ -51,8 +51,9 @@ using std::vector;
 // - output type is same as the input type
 // - NULL handling is of type NULL_INTERNAL
 //
-// The pre-compiled fn name includes the base name & input type names. eg. add_int32_int32
-#define BINARY_SYMMETRIC_SAFE_NULL_INTERNAL(NAME, TYPE)                \
+// The pre-compiled fn name includes the base name & input type names. eg.
+// divide_int64_int64
+#define BINARY_SYMMETRIC_NULL_INTERNAL(NAME, TYPE)                    \
   NativeFunction(#NAME, DataTypeVector{TYPE(), TYPE()}, TYPE(), true, \
                  RESULT_NULL_INTERNAL, STRINGIFY(NAME##_##TYPE##_##TYPE))
 
@@ -174,7 +175,7 @@ NativeFunction FunctionRegistry::pc_registry_[] = {
     NUMERIC_TYPES(BINARY_SYMMETRIC_SAFE_NULL_IF_NULL, add),
     NUMERIC_TYPES(BINARY_SYMMETRIC_SAFE_NULL_IF_NULL, subtract),
     NUMERIC_TYPES(BINARY_SYMMETRIC_SAFE_NULL_IF_NULL, multiply),
-    NUMERIC_TYPES(BINARY_SYMMETRIC_SAFE_NULL_INTERNAL, divide),
+    NUMERIC_TYPES(BINARY_SYMMETRIC_NULL_INTERNAL, divide),
     BINARY_GENERIC_SAFE_NULL_IF_NULL(mod, int64, int32, int32),
     BINARY_GENERIC_SAFE_NULL_IF_NULL(mod, int64, int64, int64),
     NUMERIC_BOOL_DATE_TYPES(BINARY_RELATIONAL_SAFE_NULL_IF_NULL, equal),

--- a/cpp/src/precompiled/arithmetic_ops.cc
+++ b/cpp/src/precompiled/arithmetic_ops.cc
@@ -152,19 +152,19 @@ NUMERIC_BOOL_DATE_FUNCTION(IS_DISTINCT_FROM)
 NUMERIC_BOOL_DATE_FUNCTION(IS_NOT_DISTINCT_FROM)
 
 // divide - handles invalid args as nulls
-#define DIVIDE_NULL_INTERNAL(TYPE)                                                 \
-  FORCE_INLINE                                                                     \
-  TYPE divide_##TYPE##_##TYPE(TYPE in1, boolean is_valid1, TYPE in2,               \
-                              boolean is_valid2, bool *out_valid) {                \
-    *out_valid = false;                                                            \
-    if (!is_valid1 || !is_valid2) {                                                \
-      return 0;                                                                    \
-    }                                                                              \
-    if (in2 == 0) {                                                                \
-      return 0;                                                                    \
-    }                                                                              \
-    *out_valid = true;                                                             \
-    return in1 / in2;                                                              \
+#define DIVIDE_NULL_INTERNAL(TYPE)                                                      \
+  FORCE_INLINE                                                                          \
+  TYPE divide_##TYPE##_##TYPE(TYPE in1, boolean is_valid1, TYPE in2, boolean is_valid2, \
+                              bool *out_valid) {                                        \
+    *out_valid = false;                                                                 \
+    if (!is_valid1 || !is_valid2) {                                                     \
+      return 0;                                                                         \
+    }                                                                                   \
+    if (in2 == 0) {                                                                     \
+      return 0;                                                                         \
+    }                                                                                   \
+    *out_valid = true;                                                                  \
+    return in1 / in2;                                                                   \
   }
 
 NUMERIC_FUNCTION(DIVIDE_NULL_INTERNAL)

--- a/cpp/src/precompiled/arithmetic_ops.cc
+++ b/cpp/src/precompiled/arithmetic_ops.cc
@@ -58,7 +58,6 @@ extern "C" {
 NUMERIC_TYPES(BINARY_SYMMETRIC, add, +)
 NUMERIC_TYPES(BINARY_SYMMETRIC, subtract, -)
 NUMERIC_TYPES(BINARY_SYMMETRIC, multiply, *)
-NUMERIC_TYPES(BINARY_SYMMETRIC, divide, /)
 
 MOD_OP(mod, int64, int32, int32)
 MOD_OP(mod, int64, int64, int64)
@@ -151,5 +150,23 @@ boolean not_boolean(boolean in) { return !in; }
 
 NUMERIC_BOOL_DATE_FUNCTION(IS_DISTINCT_FROM)
 NUMERIC_BOOL_DATE_FUNCTION(IS_NOT_DISTINCT_FROM)
+
+// divide - handles invalid args as nulls
+#define DIVIDE_NULL_INTERNAL(TYPE)                                                 \
+  FORCE_INLINE                                                                     \
+  TYPE divide_##TYPE##_##TYPE(TYPE in1, boolean is_valid1, TYPE in2,               \
+                              boolean is_valid2, bool *out_valid) {                \
+    *out_valid = false;                                                            \
+    if (!is_valid1 || !is_valid2) {                                                \
+      return 0;                                                                    \
+    }                                                                              \
+    if (in2 == 0) {                                                                \
+      return 0;                                                                    \
+    }                                                                              \
+    *out_valid = true;                                                             \
+    return in1 / in2;                                                              \
+  }
+
+NUMERIC_FUNCTION(DIVIDE_NULL_INTERNAL)
 
 }  // extern "C"

--- a/cpp/src/precompiled/arithmetic_ops_test.cc
+++ b/cpp/src/precompiled/arithmetic_ops_test.cc
@@ -35,4 +35,19 @@ TEST(TestArithmeticOps, TestIsDistinctFrom) {
 
 TEST(TestArithmeticOps, TestMod) { EXPECT_EQ(mod_int64_int32(10, 0), 10); }
 
+TEST(TestArithmeticOps, TestDivide) {
+  boolean is_valid;
+  int64 out = divide_int64_int64(10, true, 0, true, &is_valid);
+  EXPECT_EQ(out, 0);
+  EXPECT_EQ(is_valid, false);
+
+  out = divide_int64_int64(10, true, 2, false, &is_valid);
+  EXPECT_EQ(out, 0);
+  EXPECT_EQ(is_valid, false);
+
+  out = divide_int64_int64(10, true, 2, true, &is_valid);
+  EXPECT_EQ(out, 5);
+  EXPECT_EQ(is_valid, true);
+}
+
 }  // namespace gandiva

--- a/cpp/src/precompiled/types.h
+++ b/cpp/src/precompiled/types.h
@@ -119,6 +119,9 @@ int32 mem_compare(const char *left, int32 left_len, const char *right, int32 rig
 
 int32 mod_int64_int32(int64 left, int32 right);
 
+int64 divide_int64_int64(int64 in1, boolean is_valid1, int64 in2,
+                         boolean is_valid2, bool *out_valid);
+
 }  // extern "C"
 
 #endif  // PRECOMPILED_TYPES_H

--- a/cpp/src/precompiled/types.h
+++ b/cpp/src/precompiled/types.h
@@ -119,8 +119,8 @@ int32 mem_compare(const char *left, int32 left_len, const char *right, int32 rig
 
 int32 mod_int64_int32(int64 left, int32 right);
 
-int64 divide_int64_int64(int64 in1, boolean is_valid1, int64 in2,
-                         boolean is_valid2, bool *out_valid);
+int64 divide_int64_int64(int64 in1, boolean is_valid1, int64 in2, boolean is_valid2,
+                         bool *out_valid);
 
 }  // extern "C"
 


### PR DESCRIPTION
Made divide null safe. Handles divide by zero and invalid inputs now.