### PR TITLE
GDV-109: [C++] short-circuit regex startsW/endsW

### DIFF
--- a/cpp/integ/utf8_test.cc
+++ b/cpp/integ/utf8_test.cc
@@ -208,4 +208,55 @@ TEST_F(TestUtf8, TestLike) {
   EXPECT_ARROW_ARRAY_EQUALS(exp, outputs.at(0));
 }
 
+TEST_F(TestUtf8, TestBeginsEnds) {
+  // schema for input fields
+  auto field_a = field("a", utf8());
+  auto schema = arrow::schema({field_a});
+
+  // output fields
+  auto res1 = field("res1", boolean());
+  auto res2 = field("res2", boolean());
+
+  // build expressions.
+  // like(literal("spark%"), a)
+  // like(literal("%spark"), a)
+
+  auto node_a = TreeExprBuilder::MakeField(field_a);
+  auto literal_begin = TreeExprBuilder::MakeStringLiteral("spark%");
+  auto is_like1 =
+      TreeExprBuilder::MakeFunction("like", {node_a, literal_begin}, boolean());
+  auto expr1 = TreeExprBuilder::MakeExpression(is_like1, res1);
+
+  auto literal_end = TreeExprBuilder::MakeStringLiteral("%spark");
+  auto is_like2 = TreeExprBuilder::MakeFunction("like", {node_a, literal_end}, boolean());
+  auto expr2 = TreeExprBuilder::MakeExpression(is_like2, res2);
+
+  // Build a projector for the expressions.
+  std::shared_ptr<Projector> projector;
+  Status status = Projector::Make(schema, {expr1, expr2}, &projector);
+  EXPECT_TRUE(status.ok()) << status.message();
+
+  // Create a row-batch with some sample data
+  int num_records = 4;
+  auto array_a =
+      MakeArrowArrayUtf8({"park", "sparkle", "bright spark and fire", "fiery spark"},
+                         {true, true, true, true});
+
+  // expected output
+  auto exp1 = MakeArrowArrayBool({false, true, false, false}, {true, true, true, true});
+  auto exp2 = MakeArrowArrayBool({false, false, false, true}, {true, true, true, true});
+
+  // prepare input record batch
+  auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array_a});
+
+  // Evaluate expression
+  arrow::ArrayVector outputs;
+  status = projector->Evaluate(*in_batch, pool_, &outputs);
+  EXPECT_TRUE(status.ok()) << status.message();
+
+  // Validate results
+  EXPECT_ARROW_ARRAY_EQUALS(exp1, outputs.at(0));
+  EXPECT_ARROW_ARRAY_EQUALS(exp2, outputs.at(1));
+}
+
 }  // namespace gandiva

--- a/cpp/src/codegen/expr_decomposer.cc
+++ b/cpp/src/codegen/expr_decomposer.cc
@@ -43,9 +43,22 @@ Status ExprDecomposer::Visit(const FieldNode &node) {
   return Status::OK();
 }
 
+// Try and optimize a function node, by substituting with cheaper alternatives.
+// eg. replacing 'like' with 'starts_with' can save function calls at evaluation
+// time.
+const FunctionNode ExprDecomposer::TryOptimize(const FunctionNode &node) {
+  if (node.descriptor()->name() == "like") {
+    return LikeHolder::TryOptimize(node);
+  } else {
+    return node;
+  }
+}
+
 // Decompose a field node - wherever possible, merge the validity vectors of the
 // child nodes.
-Status ExprDecomposer::Visit(const FunctionNode &node) {
+Status ExprDecomposer::Visit(const FunctionNode &in_node) {
+  auto node = TryOptimize(in_node);
+
   auto desc = node.descriptor();
   FunctionSignature signature(desc->name(), desc->params(), desc->return_type());
   const NativeFunction *native_function = registry_.LookupSignature(signature);

--- a/cpp/src/codegen/expr_decomposer.h
+++ b/cpp/src/codegen/expr_decomposer.h
@@ -56,6 +56,9 @@ class ExprDecomposer : public NodeVisitor {
   Status Visit(const LiteralNode &node) override;
   Status Visit(const BooleanNode &node) override;
 
+  // Optimize a function node, if possible.
+  const FunctionNode TryOptimize(const FunctionNode &node);
+
   // stack of if nodes.
   class IfStackEntry {
    public:

--- a/cpp/src/codegen/function_registry.cc
+++ b/cpp/src/codegen/function_registry.cc
@@ -352,8 +352,10 @@ NativeFunction FunctionRegistry::pc_registry_[] = {
     VAR_LEN_TYPES(BINARY_RELATIONAL_SAFE_NULL_IF_NULL, greater_than),
     VAR_LEN_TYPES(BINARY_RELATIONAL_SAFE_NULL_IF_NULL, greater_than_or_equal_to),
 
-    VAR_LEN_TYPES(BINARY_RELATIONAL_SAFE_NULL_IF_NULL, starts_with),
-    VAR_LEN_TYPES(BINARY_RELATIONAL_SAFE_NULL_IF_NULL, ends_with),
+    BINARY_RELATIONAL_SAFE_NULL_IF_NULL(starts_with, utf8),
+    BINARY_RELATIONAL_SAFE_NULL_IF_NULL(ends_with, utf8),
+    BINARY_RELATIONAL_SAFE_NULL_IF_NULL(starts_with_plus_one, utf8),
+    BINARY_RELATIONAL_SAFE_NULL_IF_NULL(ends_with_plus_one, utf8),
     NativeFunction("like", DataTypeVector{utf8(), utf8()}, boolean(), true /*null_safe*/,
                    RESULT_NULL_IF_NULL, "like_utf8_utf8", true /*needs_holder*/),
 

--- a/cpp/src/codegen/function_registry.cc
+++ b/cpp/src/codegen/function_registry.cc
@@ -352,6 +352,8 @@ NativeFunction FunctionRegistry::pc_registry_[] = {
     VAR_LEN_TYPES(BINARY_RELATIONAL_SAFE_NULL_IF_NULL, greater_than),
     VAR_LEN_TYPES(BINARY_RELATIONAL_SAFE_NULL_IF_NULL, greater_than_or_equal_to),
 
+    VAR_LEN_TYPES(BINARY_RELATIONAL_SAFE_NULL_IF_NULL, starts_with),
+    VAR_LEN_TYPES(BINARY_RELATIONAL_SAFE_NULL_IF_NULL, ends_with),
     NativeFunction("like", DataTypeVector{utf8(), utf8()}, boolean(), true /*null_safe*/,
                    RESULT_NULL_IF_NULL, "like_utf8_utf8", true /*needs_holder*/),
 

--- a/cpp/src/codegen/like_holder.cc
+++ b/cpp/src/codegen/like_holder.cc
@@ -24,6 +24,8 @@ namespace helpers {
 
 RE2 LikeHolder::starts_with_regex_(R"((\w|\s)*\.\*)");
 RE2 LikeHolder::ends_with_regex_(R"(\.\*(\w|\s)*)");
+RE2 LikeHolder::starts_with_plus_one_regex_(R"((\w|\s)*\.)");
+RE2 LikeHolder::ends_with_plus_one_regex_(R"(\.(\w|\s)*)");
 
 // Short-circuit pattern matches for the two common sub cases :
 // - starts_with and ends_with.
@@ -45,6 +47,18 @@ const FunctionNode LikeHolder::TryOptimize(const FunctionNode &node) {
       auto suffix_node =
           std::make_shared<LiteralNode>(literal_type, LiteralHolder(suffix), false);
       return FunctionNode("ends_with", {node.children().at(0), suffix_node},
+                          node.return_type());
+    } else if (RE2::FullMatch(pattern, starts_with_plus_one_regex_)) {
+      auto prefix = pattern.substr(0, pattern.length() - 1);  // trim .
+      auto prefix_node =
+          std::make_shared<LiteralNode>(literal_type, LiteralHolder(prefix), false);
+      return FunctionNode("starts_with_plus_one", {node.children().at(0), prefix_node},
+                          node.return_type());
+    } else if (RE2::FullMatch(pattern, ends_with_plus_one_regex_)) {
+      auto suffix = pattern.substr(1);  // skip .
+      auto suffix_node =
+          std::make_shared<LiteralNode>(literal_type, LiteralHolder(suffix), false);
+      return FunctionNode("ends_with_plus_one", {node.children().at(0), suffix_node},
                           node.return_type());
     }
   }

--- a/cpp/src/codegen/like_holder.cc
+++ b/cpp/src/codegen/like_holder.cc
@@ -22,27 +22,25 @@ namespace gandiva {
 namespace helpers {
 #endif
 
+RE2 LikeHolder::starts_with_regex_(R"((\w|\s)*\.\*)");
+RE2 LikeHolder::ends_with_regex_(R"(\.\*(\w|\s)*)");
+
 // Short-circuit pattern matches for the two common sub cases :
 // - starts_with and ends_with.
 const FunctionNode LikeHolder::TryOptimize(const FunctionNode &node) {
-  static std::string starts_with_pattern(R"((\w|\s)*\.\*)");
-  static std::string ends_with_pattern(R"(\.\*(\w|\s)*)");
-  static RE2 starts_with_regex(starts_with_pattern);
-  static RE2 ends_with_regex(ends_with_pattern);
-
   std::shared_ptr<LikeHolder> holder;
   auto status = Make(node, &holder);
   if (status.ok()) {
     std::string &pattern = holder->pattern_;
     auto literal_type = node.children().at(1)->return_type();
 
-    if (RE2::FullMatch(pattern, starts_with_regex)) {
+    if (RE2::FullMatch(pattern, starts_with_regex_)) {
       auto prefix = pattern.substr(0, pattern.length() - 2);  // trim .*
       auto prefix_node =
           std::make_shared<LiteralNode>(literal_type, LiteralHolder(prefix), false);
       return FunctionNode("starts_with", {node.children().at(0), prefix_node},
                           node.return_type());
-    } else if (RE2::FullMatch(pattern, ends_with_regex)) {
+    } else if (RE2::FullMatch(pattern, ends_with_regex_)) {
       auto suffix = pattern.substr(2);  // skip .*
       auto suffix_node =
           std::make_shared<LiteralNode>(literal_type, LiteralHolder(suffix), false);

--- a/cpp/src/codegen/like_holder.cc
+++ b/cpp/src/codegen/like_holder.cc
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 #include "codegen/like_holder.h"
-
-#include <regex>
 #include "codegen/node.h"
 #include "codegen/regex_util.h"
 
@@ -23,6 +21,39 @@ namespace gandiva {
 #ifdef GDV_HELPERS
 namespace helpers {
 #endif
+
+// Short-circuit pattern matches for the two common sub cases :
+// - starts_with and ends_with.
+const FunctionNode LikeHolder::TryOptimize(const FunctionNode &node) {
+  static std::string starts_with_pattern(R"((\w|\s)*\.\*)");
+  static std::string ends_with_pattern(R"(\.\*(\w|\s)*)");
+  static RE2 starts_with_regex(starts_with_pattern);
+  static RE2 ends_with_regex(ends_with_pattern);
+
+  std::shared_ptr<LikeHolder> holder;
+  auto status = Make(node, &holder);
+  if (status.ok()) {
+    std::string &pattern = holder->pattern_;
+    auto literal_type = node.children().at(1)->return_type();
+
+    if (RE2::FullMatch(pattern, starts_with_regex)) {
+      auto prefix = pattern.substr(0, pattern.length() - 2);  // trim .*
+      auto prefix_node =
+          std::make_shared<LiteralNode>(literal_type, LiteralHolder(prefix), false);
+      return FunctionNode("starts_with", {node.children().at(0), prefix_node},
+                          node.return_type());
+    } else if (RE2::FullMatch(pattern, ends_with_regex)) {
+      auto suffix = pattern.substr(2);  // skip .*
+      auto suffix_node =
+          std::make_shared<LiteralNode>(literal_type, LiteralHolder(suffix), false);
+      return FunctionNode("ends_with", {node.children().at(0), suffix_node},
+                          node.return_type());
+    }
+  }
+
+  // didn't hit any of the optimisation paths. return original.
+  return node;
+}
 
 Status LikeHolder::Make(const FunctionNode &node, std::shared_ptr<LikeHolder> *holder) {
   if (node.children().size() != 2) {

--- a/cpp/src/codegen/like_holder.h
+++ b/cpp/src/codegen/like_holder.h
@@ -46,6 +46,9 @@ class LikeHolder : public FunctionHolder {
 
   std::string pattern_;  // posix pattern string, to help debugging
   RE2 regex_;            // compiled regex for the pattern
+
+  static RE2 starts_with_regex_;  // pre-compiled pattern for matching starts_with
+  static RE2 ends_with_regex_;    // pre-compiled pattern for matching ends_with
 };
 
 #ifdef GDV_HELPERS

--- a/cpp/src/codegen/like_holder.h
+++ b/cpp/src/codegen/like_holder.h
@@ -35,6 +35,9 @@ class LikeHolder : public FunctionHolder {
 
   static Status Make(const std::string &sql_pattern, std::shared_ptr<LikeHolder> *holder);
 
+  // Try and optimise a function node with a "like" pattern.
+  static const FunctionNode TryOptimize(const FunctionNode &node);
+
   /// Return true if the data matches the pattern.
   bool operator()(const std::string &data) { return RE2::FullMatch(data, regex_); }
 

--- a/cpp/src/codegen/like_holder.h
+++ b/cpp/src/codegen/like_holder.h
@@ -49,6 +49,10 @@ class LikeHolder : public FunctionHolder {
 
   static RE2 starts_with_regex_;  // pre-compiled pattern for matching starts_with
   static RE2 ends_with_regex_;    // pre-compiled pattern for matching ends_with
+  static RE2 starts_with_plus_one_regex_;  // pre-compiled pattern for matching
+                                           // starts_with_plus_one
+  static RE2
+      ends_with_plus_one_regex_;  // pre-compiled pattern for matching ends_with_plus_one
 };
 
 #ifdef GDV_HELPERS

--- a/cpp/src/codegen/like_holder_test.cc
+++ b/cpp/src/codegen/like_holder_test.cc
@@ -22,7 +22,15 @@
 
 namespace gandiva {
 
-class TestLikeHolder : public ::testing::Test {};
+class TestLikeHolder : public ::testing::Test {
+ public:
+  FunctionNode BuildLike(std::string pattern) {
+    auto field = std::make_shared<FieldNode>(arrow::field("in", arrow::utf8()));
+    auto pattern_node =
+        std::make_shared<LiteralNode>(arrow::utf8(), LiteralHolder(pattern), false);
+    return FunctionNode("like", {field, pattern_node}, arrow::boolean());
+  }
+};
 
 TEST_F(TestLikeHolder, TestMatchAny) {
   std::shared_ptr<LikeHolder> like_holder;
@@ -71,6 +79,28 @@ TEST_F(TestLikeHolder, TestRegexEscape) {
   EXPECT_TRUE(status.ok()) << status.message();
 
   EXPECT_EQ(res, "%hello_abc.def#");
+}
+
+TEST_F(TestLikeHolder, TestOptimise) {
+  // optimise for 'starts_with'
+  auto fnode = LikeHolder::TryOptimize(BuildLike("xy 123z%"));
+  EXPECT_EQ(fnode.descriptor()->name(), "starts_with");
+  EXPECT_EQ(fnode.ToString(), "bool starts_with(utf8, (string) xy 123z)");
+
+  // optimise for 'ends_with'
+  fnode = LikeHolder::TryOptimize(BuildLike("%xyz"));
+  EXPECT_EQ(fnode.descriptor()->name(), "ends_with");
+  EXPECT_EQ(fnode.ToString(), "bool ends_with(utf8, (string) xyz)");
+
+  // no optimisation for others.
+  fnode = LikeHolder::TryOptimize(BuildLike("%xyz%"));
+  EXPECT_EQ(fnode.descriptor()->name(), "like");
+
+  fnode = LikeHolder::TryOptimize(BuildLike("xyz?"));
+  EXPECT_EQ(fnode.descriptor()->name(), "like");
+
+  fnode = LikeHolder::TryOptimize(BuildLike("?xyz"));
+  EXPECT_EQ(fnode.descriptor()->name(), "like");
 }
 
 int main(int argc, char **argv) {

--- a/cpp/src/codegen/like_holder_test.cc
+++ b/cpp/src/codegen/like_holder_test.cc
@@ -92,14 +92,24 @@ TEST_F(TestLikeHolder, TestOptimise) {
   EXPECT_EQ(fnode.descriptor()->name(), "ends_with");
   EXPECT_EQ(fnode.ToString(), "bool ends_with(utf8, (string) xyz)");
 
+  // optimise for 'starts_with_plus_one
+  fnode = LikeHolder::TryOptimize(BuildLike("xyz_"));
+  EXPECT_EQ(fnode.ToString(), "bool starts_with_plus_one(utf8, (string) xyz)");
+
+  fnode = LikeHolder::TryOptimize(BuildLike("_xyz"));
+  EXPECT_EQ(fnode.ToString(), "bool ends_with_plus_one(utf8, (string) xyz)");
+
   // no optimisation for others.
   fnode = LikeHolder::TryOptimize(BuildLike("%xyz%"));
   EXPECT_EQ(fnode.descriptor()->name(), "like");
 
-  fnode = LikeHolder::TryOptimize(BuildLike("xyz?"));
+  fnode = LikeHolder::TryOptimize(BuildLike("_xyz_"));
   EXPECT_EQ(fnode.descriptor()->name(), "like");
 
-  fnode = LikeHolder::TryOptimize(BuildLike("?xyz"));
+  fnode = LikeHolder::TryOptimize(BuildLike("%xyz_"));
+  EXPECT_EQ(fnode.descriptor()->name(), "like");
+
+  fnode = LikeHolder::TryOptimize(BuildLike("x_yz%"));
   EXPECT_EQ(fnode.descriptor()->name(), "like");
 }
 

--- a/cpp/src/codegen/node.h
+++ b/cpp/src/codegen/node.h
@@ -92,9 +92,7 @@ class FieldNode : public Node {
 /// \brief Node in the expression tree, representing a function.
 class FunctionNode : public Node {
  public:
-  FunctionNode(FuncDescriptorPtr descriptor, const NodeVector &children,
-               DataTypePtr retType)
-      : Node(retType), descriptor_(descriptor), children_(children) {}
+  FunctionNode(const std::string &name, const NodeVector &children, DataTypePtr retType);
 
   Status Accept(NodeVisitor &visitor) const override { return visitor.Visit(*this); }
 
@@ -117,26 +115,20 @@ class FunctionNode : public Node {
     return ss.str();
   }
 
-  /// Make a function node with params types specified by 'children', and
-  /// having return type ret_type.
-  static NodePtr MakeFunction(const std::string &name, const NodeVector &children,
-                              DataTypePtr return_type);
-
  private:
   FuncDescriptorPtr descriptor_;
   NodeVector children_;
 };
 
-inline NodePtr FunctionNode::MakeFunction(const std::string &name,
-                                          const NodeVector &children,
-                                          DataTypePtr return_type) {
+inline FunctionNode::FunctionNode(const std::string &name, const NodeVector &children,
+                                  DataTypePtr return_type)
+    : Node(return_type), children_(children) {
   DataTypeVector param_types;
   for (auto &child : children) {
     param_types.push_back(child->return_type());
   }
 
-  auto func_desc = FuncDescriptorPtr(new FuncDescriptor(name, param_types, return_type));
-  return NodePtr(new FunctionNode(func_desc, children, return_type));
+  descriptor_ = FuncDescriptorPtr(new FuncDescriptor(name, param_types, return_type));
 }
 
 /// \brief Node in the expression tree, representing an if-else expression.

--- a/cpp/src/codegen/tree_expr_builder.cc
+++ b/cpp/src/codegen/tree_expr_builder.cc
@@ -100,7 +100,7 @@ NodePtr TreeExprBuilder::MakeFunction(const std::string &name, const NodeVector 
   if (result_type == nullptr) {
     return nullptr;
   }
-  return FunctionNode::MakeFunction(name, params, result_type);
+  return std::make_shared<FunctionNode>(name, params, result_type);
 }
 
 NodePtr TreeExprBuilder::MakeIf(NodePtr condition, NodePtr then_node, NodePtr else_node,
@@ -144,7 +144,7 @@ ExpressionPtr TreeExprBuilder::MakeExpression(const std::string &function,
     auto node = MakeField(field);
     field_nodes.push_back(node);
   }
-  auto func_node = FunctionNode::MakeFunction(function, field_nodes, out_field->type());
+  auto func_node = MakeFunction(function, field_nodes, out_field->type());
   return MakeExpression(func_node, out_field);
 }
 
@@ -167,7 +167,7 @@ ConditionPtr TreeExprBuilder::MakeCondition(const std::string &function,
     field_nodes.push_back(node);
   }
 
-  auto func_node = FunctionNode::MakeFunction(function, field_nodes, arrow::boolean());
+  auto func_node = MakeFunction(function, field_nodes, arrow::boolean());
   return ConditionPtr(new Condition(func_node));
 }
 

--- a/cpp/src/precompiled/string_ops.cc
+++ b/cpp/src/precompiled/string_ops.cc
@@ -47,8 +47,8 @@ int32 mem_compare(const char *left, int32 left_len, const char *right, int32 rig
 }
 
 // Expand inner macro for all varlen types.
-#define VAR_LEN_TYPES(INNER, NAME, OP) \
-  INNER(NAME, utf8, OP)                \
+#define VAR_LEN_OP_TYPES(INNER, NAME, OP) \
+  INNER(NAME, utf8, OP)                   \
   INNER(NAME, binary, OP)
 
 // Relational binary fns : left, right params are same, return is bool.
@@ -59,11 +59,34 @@ int32 mem_compare(const char *left, int32 left_len, const char *right, int32 rig
     return mem_compare(left, left_len, right, right_len) OP 0;                   \
   }
 
-VAR_LEN_TYPES(BINARY_RELATIONAL, equal, ==)
-VAR_LEN_TYPES(BINARY_RELATIONAL, not_equal, !=)
-VAR_LEN_TYPES(BINARY_RELATIONAL, less_than, <)
-VAR_LEN_TYPES(BINARY_RELATIONAL, less_than_or_equal_to, <=)
-VAR_LEN_TYPES(BINARY_RELATIONAL, greater_than, >)
-VAR_LEN_TYPES(BINARY_RELATIONAL, greater_than_or_equal_to, >=)
+VAR_LEN_OP_TYPES(BINARY_RELATIONAL, equal, ==)
+VAR_LEN_OP_TYPES(BINARY_RELATIONAL, not_equal, !=)
+VAR_LEN_OP_TYPES(BINARY_RELATIONAL, less_than, <)
+VAR_LEN_OP_TYPES(BINARY_RELATIONAL, less_than_or_equal_to, <=)
+VAR_LEN_OP_TYPES(BINARY_RELATIONAL, greater_than, >)
+VAR_LEN_OP_TYPES(BINARY_RELATIONAL, greater_than_or_equal_to, >=)
+
+// Expand inner macro for all varlen types.
+#define VAR_LEN_TYPES(INNER) \
+  INNER(utf8)                \
+  INNER(binary)
+
+#define STARTS_WITH(TYPE)                                                                \
+  FORCE_INLINE                                                                           \
+  bool starts_with##_##TYPE##_##TYPE(const TYPE data, int32 data_len, const TYPE prefix, \
+                                     int32 prefix_len) {                                 \
+    return ((data_len >= prefix_len) && (memcmp(data, prefix, prefix_len) == 0));        \
+  }
+
+#define ENDS_WITH(TYPE)                                                                \
+  FORCE_INLINE                                                                         \
+  bool ends_with##_##TYPE##_##TYPE(const TYPE data, int32 data_len, const TYPE suffix, \
+                                   int32 suffix_len) {                                 \
+    return ((data_len >= suffix_len) &&                                                \
+            (memcmp(data + data_len - suffix_len, suffix, suffix_len) == 0));          \
+  }
+
+VAR_LEN_TYPES(STARTS_WITH)
+VAR_LEN_TYPES(ENDS_WITH)
 
 }  // extern "C"

--- a/cpp/src/precompiled/string_ops.cc
+++ b/cpp/src/precompiled/string_ops.cc
@@ -71,22 +71,29 @@ VAR_LEN_OP_TYPES(BINARY_RELATIONAL, greater_than_or_equal_to, >=)
   INNER(utf8)                \
   INNER(binary)
 
-#define STARTS_WITH(TYPE)                                                                \
-  FORCE_INLINE                                                                           \
-  bool starts_with##_##TYPE##_##TYPE(const TYPE data, int32 data_len, const TYPE prefix, \
-                                     int32 prefix_len) {                                 \
-    return ((data_len >= prefix_len) && (memcmp(data, prefix, prefix_len) == 0));        \
-  }
+FORCE_INLINE
+bool starts_with_utf8_utf8(const char *data, int32 data_len, const char *prefix,
+                           int32 prefix_len) {
+  return ((data_len >= prefix_len) && (memcmp(data, prefix, prefix_len) == 0));
+}
 
-#define ENDS_WITH(TYPE)                                                                \
-  FORCE_INLINE                                                                         \
-  bool ends_with##_##TYPE##_##TYPE(const TYPE data, int32 data_len, const TYPE suffix, \
-                                   int32 suffix_len) {                                 \
-    return ((data_len >= suffix_len) &&                                                \
-            (memcmp(data + data_len - suffix_len, suffix, suffix_len) == 0));          \
-  }
+FORCE_INLINE
+bool ends_with_utf8_utf8(const char *data, int32 data_len, const char *suffix,
+                         int32 suffix_len) {
+  return ((data_len >= suffix_len) &&
+          (memcmp(data + data_len - suffix_len, suffix, suffix_len) == 0));
+}
 
-VAR_LEN_TYPES(STARTS_WITH)
-VAR_LEN_TYPES(ENDS_WITH)
+FORCE_INLINE
+bool starts_with_plus_one_utf8_utf8(const char *data, int32 data_len, const char *prefix,
+                                    int32 prefix_len) {
+  return ((data_len == prefix_len + 1) && (memcmp(data, prefix, prefix_len) == 0));
+}
+
+FORCE_INLINE
+bool ends_with_plus_one_utf8_utf8(const char *data, int32 data_len, const char *suffix,
+                                  int32 suffix_len) {
+  return ((data_len == suffix_len + 1) && (memcmp(data + 1, suffix, suffix_len) == 0));
+}
 
 }  // extern "C"

--- a/cpp/src/precompiled/string_ops_test.cc
+++ b/cpp/src/precompiled/string_ops_test.cc
@@ -34,4 +34,32 @@ TEST(TestStringOps, TestCompare) {
   EXPECT_GT(mem_compare(left, 7, right, 5), 0);
 }
 
+TEST(TestStringOps, TestBeginsEnds) {
+  // starts_with
+  EXPECT_TRUE(starts_with_utf8_utf8("hello sir", 9, "hello", 5));
+  EXPECT_TRUE(starts_with_utf8_utf8("hellos", 6, "hello", 5));
+  EXPECT_TRUE(starts_with_utf8_utf8("hello", 5, "hello", 5));
+  EXPECT_FALSE(starts_with_utf8_utf8("hell", 4, "hello", 5));
+  EXPECT_FALSE(starts_with_utf8_utf8("world hello", 11, "hello", 5));
+
+  // ends_with
+  EXPECT_TRUE(ends_with_utf8_utf8("hello sir", 9, "sir", 3));
+  EXPECT_TRUE(ends_with_utf8_utf8("ssir", 4, "sir", 3));
+  EXPECT_TRUE(ends_with_utf8_utf8("sir", 3, "sir", 3));
+  EXPECT_FALSE(ends_with_utf8_utf8("ir", 2, "sir", 3));
+  EXPECT_FALSE(ends_with_utf8_utf8("hello", 5, "sir", 3));
+
+  // starts_with_plus_one
+  EXPECT_TRUE(starts_with_plus_one_utf8_utf8("hello ", 6, "hello", 5));
+  EXPECT_FALSE(starts_with_plus_one_utf8_utf8("hello world", 11, "hello", 5));
+  EXPECT_FALSE(starts_with_plus_one_utf8_utf8("hello", 5, "hello", 5));
+  EXPECT_FALSE(starts_with_plus_one_utf8_utf8("hell", 4, "hello", 5));
+
+  // ends_with_plus_one
+  EXPECT_TRUE(ends_with_plus_one_utf8_utf8("gworld", 6, "world", 5));
+  EXPECT_FALSE(ends_with_plus_one_utf8_utf8("hello world", 11, "world", 5));
+  EXPECT_FALSE(ends_with_plus_one_utf8_utf8("world", 5, "world", 5));
+  EXPECT_FALSE(ends_with_plus_one_utf8_utf8("worl", 4, "world", 5));
+}
+
 }  // namespace gandiva

--- a/cpp/src/precompiled/types.h
+++ b/cpp/src/precompiled/types.h
@@ -122,6 +122,15 @@ int32 mod_int64_int32(int64 left, int32 right);
 int64 divide_int64_int64(int64 in1, boolean is_valid1, int64 in2, boolean is_valid2,
                          bool *out_valid);
 
+bool starts_with_utf8_utf8(const char *data, int32 data_len, const char *prefix,
+                           int32 prefix_len);
+bool ends_with_utf8_utf8(const char *data, int32 data_len, const char *suffix,
+                         int32 suffix_len);
+bool starts_with_plus_one_utf8_utf8(const char *data, int32 data_len, const char *prefix,
+                                    int32 prefix_len);
+bool ends_with_plus_one_utf8_utf8(const char *data, int32 data_len, const char *suffix,
+                                  int32 suffix_len);
+
 }  // extern "C"
 
 #endif  // PRECOMPILED_TYPES_H


### PR DESCRIPTION
- for trivial patterns like startsWith/endsWith, short-circuit
  to avoid function-calls, pointer-indirections