### PR TITLE
GDV-119: fix a bug caused due to fake cache hits

### DIFF
--- a/cpp/integ/projector_test.cc
+++ b/cpp/integ/projector_test.cc
@@ -74,6 +74,50 @@ TEST_F(TestProjector, TestProjectCache) {
   EXPECT_TRUE(cached_projector.get() != should_be_new_projector1.get());
 }
 
+TEST_F(TestProjector, TestProjectCacheDouble) {
+  auto schema = arrow::schema({});
+  auto res = field("result", arrow::float64());
+
+  double d0 = 1.23456788912345677E18;
+  double d1 = 1.23456789012345677E18;
+
+  auto literal0 = TreeExprBuilder::MakeLiteral(d0);
+  auto expr0 = TreeExprBuilder::MakeExpression(literal0, res);
+  std::shared_ptr<Projector> projector0;
+  auto status = Projector::Make(schema, {expr0}, &projector0);
+  EXPECT_TRUE(status.ok()) << status.message();
+
+  auto literal1 = TreeExprBuilder::MakeLiteral(d1);
+  auto expr1 = TreeExprBuilder::MakeExpression(literal1, res);
+  std::shared_ptr<Projector> projector1;
+  status = Projector::Make(schema, {expr1}, &projector1);
+  EXPECT_TRUE(status.ok()) << status.message();
+
+  EXPECT_TRUE(projector0.get() != projector1.get());
+}
+
+TEST_F(TestProjector, TestProjectCacheFloat) {
+  auto schema = arrow::schema({});
+  auto res = field("result", arrow::float32());
+
+  float f0 = 12345678891.000000;
+  float f1 = f0 - 1000;
+
+  auto literal0 = TreeExprBuilder::MakeLiteral(f0);
+  auto expr0 = TreeExprBuilder::MakeExpression(literal0, res);
+  std::shared_ptr<Projector> projector0;
+  auto status = Projector::Make(schema, {expr0}, &projector0);
+  EXPECT_TRUE(status.ok()) << status.message();
+
+  auto literal1 = TreeExprBuilder::MakeLiteral(f1);
+  auto expr1 = TreeExprBuilder::MakeExpression(literal1, res);
+  std::shared_ptr<Projector> projector1;
+  status = Projector::Make(schema, {expr1}, &projector1);
+  EXPECT_TRUE(status.ok()) << status.message();
+
+  EXPECT_TRUE(projector0.get() != projector1.get());
+}
+
 TEST_F(TestProjector, TestIntSumSub) {
   // schema for input fields
   auto field0 = field("f0", int32());

--- a/cpp/integ/to_string_test.cc
+++ b/cpp/integ/to_string_test.cc
@@ -64,7 +64,7 @@ TEST_F(TestToString, TestAll) {
   auto if_node = TreeExprBuilder::MakeIf(cond_node, then_node, else_node, int64());
   auto if_expr = TreeExprBuilder::MakeExpression(if_node, f1);
   CHECK_EXPR_TO_STRING(
-      if_expr, "if (bool lesser_than(double, (float) 0)) { int64 } else { int64 }");
+      if_expr, "if (bool lesser_than(double, (float) 0x0p+0)) { int64 } else { int64 }");
 
   auto f1_gt_100 =
       TreeExprBuilder::MakeFunction("greater_than", {f1_node, literal_node}, boolean());

--- a/cpp/integ/to_string_test.cc
+++ b/cpp/integ/to_string_test.cc
@@ -64,7 +64,8 @@ TEST_F(TestToString, TestAll) {
   auto if_node = TreeExprBuilder::MakeIf(cond_node, then_node, else_node, int64());
   auto if_expr = TreeExprBuilder::MakeExpression(if_node, f1);
   CHECK_EXPR_TO_STRING(
-      if_expr, "if (bool lesser_than(double, (float) 0x0p+0)) { int64 } else { int64 }");
+      if_expr,
+      "if (bool lesser_than(double, (float) 0 raw(0))) { int64 } else { int64 }");
 
   auto f1_gt_100 =
       TreeExprBuilder::MakeFunction("greater_than", {f1_node, literal_node}, boolean());

--- a/cpp/src/codegen/node.h
+++ b/cpp/src/codegen/node.h
@@ -65,7 +65,14 @@ class LiteralNode : public Node {
       ss << std::string("null");
       return ss.str();
     }
-    ss << holder();
+    if (return_type()->id() == arrow::Type::DOUBLE ||
+        return_type()->id() == arrow::Type::FLOAT) {
+      // The default printf in decimal can cause a loss in precision. so,
+      // print in hex.
+      ss << std::hexfloat << holder();
+    } else {
+      ss << holder();
+    }
     return ss.str();
   }
 

--- a/cpp/src/codegen/node.h
+++ b/cpp/src/codegen/node.h
@@ -65,13 +65,20 @@ class LiteralNode : public Node {
       ss << std::string("null");
       return ss.str();
     }
-    if (return_type()->id() == arrow::Type::DOUBLE ||
-        return_type()->id() == arrow::Type::FLOAT) {
-      // The default printf in decimal can cause a loss in precision. so,
-      // print in hex.
-      ss << std::hexfloat << holder();
-    } else {
-      ss << holder();
+
+    ss << holder();
+    // The default formatter prints in decimal can cause a loss in precision. so,
+    // print in hex. Can't use hexfloat since gcc 4.9 doesn't support it.
+    if (return_type()->id() == arrow::Type::DOUBLE) {
+      double dvalue = boost::get<double>(holder_);
+      uint64_t bits;
+      memcpy(&bits, &dvalue, sizeof(bits));
+      ss << " raw(" << std::hex << bits << ")";
+    } else if (return_type()->id() == arrow::Type::FLOAT) {
+      float fvalue = boost::get<float>(holder_);
+      uint32_t bits;
+      memcpy(&bits, &fvalue, sizeof(bits));
+      ss << " raw(" << std::hex << bits << ")";
     }
     return ss.str();
   }


### PR DESCRIPTION
- for doubles/floats, print in hex to avoid loss of precision