### PR TITLE
GDV-121:[CPP]Hide stdc++ from being exported.

### DIFF
--- a/cpp/src/codegen/CMakeLists.txt
+++ b/cpp/src/codegen/CMakeLists.txt
@@ -105,7 +105,11 @@ target_include_directories(gandiva_helpers
 )
 
 target_link_libraries(gandiva_helpers PRIVATE Boost::boost RE2::RE2_STATIC)
+
+# hide all symbols that are not needed.
 if (NOT APPLE)
+  # apple linker does not support version scripts, not needed since we package from travis.
+  set_target_properties(gandiva_helpers PROPERTIES LINK_FLAGS "-Wl,--version-script=${CMAKE_SOURCE_DIR}/src/codegen/symbols-helpers.map")
   target_link_libraries(gandiva_helpers LINK_PRIVATE -static-libstdc++ -static-libgcc)
 endif()
 

--- a/cpp/src/codegen/execution_context.cc
+++ b/cpp/src/codegen/execution_context.cc
@@ -20,14 +20,21 @@ namespace helpers {
 #endif
 
 void ExecutionContext::set_error_msg(const char *error_msg) {
-  if (error_msg_.empty()) {
-    error_msg_ = std::string(error_msg);
+  if (error_msg_.get() == nullptr) {
+    error_msg_.reset(new std::string(error_msg));
   }
 }
 
-std::string ExecutionContext::get_error() const { return error_msg_; }
+std::string ExecutionContext::get_error() const {
+  if (error_msg_.get() != nullptr) {
+    return *(error_msg_.get());
+  }
+  return std::string("");
+}
 
-bool ExecutionContext::has_error() const { return !error_msg_.empty(); }
+bool ExecutionContext::has_error() const {
+  return error_msg_.get() != nullptr && !(error_msg_.get()->empty());
+}
 
 #ifdef GDV_HELPERS
 }

--- a/cpp/src/codegen/execution_context.h
+++ b/cpp/src/codegen/execution_context.h
@@ -15,6 +15,7 @@
 #ifndef ERROR_HOLDER_H
 #define ERROR_HOLDER_H
 
+#include <memory>
 #include <string>
 
 namespace gandiva {
@@ -31,7 +32,7 @@ class ExecutionContext {
   bool has_error() const;
 
  private:
-  std::string error_msg_;
+  std::unique_ptr<std::string> error_msg_;
 };
 #ifdef GDV_HELPERS
 }

--- a/cpp/src/codegen/symbols-helpers.map
+++ b/cpp/src/codegen/symbols-helpers.map
@@ -1,0 +1,4 @@
+{
+  global: extern "C++" { gandiva*; like*;};
+  local: *;
+};

--- a/cpp/src/jni/CMakeLists.txt
+++ b/cpp/src/jni/CMakeLists.txt
@@ -53,6 +53,12 @@ target_include_directories(gandiva_jni
     ${CMAKE_SOURCE_DIR}/src
 )
 
+# filter out everything that is not needed for the jni bridge
+# statically linked stdc++ has conflicts with stdc++ loaded by other libraries.
+if (NOT APPLE)
+set_target_properties(gandiva_jni PROPERTIES LINK_FLAGS "-Wl,--version-script=${CMAKE_SOURCE_DIR}/src/jni/symbols.map")
+endif()
+
 # PROTOBUF is a private dependency i.e users of gandiva also will not have a dependency on protobuf.
 target_link_libraries(gandiva_jni
   PRIVATE

--- a/cpp/src/jni/symbols.map
+++ b/cpp/src/jni/symbols.map
@@ -1,0 +1,4 @@
+{
+  global: extern "C++" { gandiva*; Java*; JNI*; };
+  local: *;
+};


### PR DESCRIPTION
Statically linked stdc++ causes issues when other libraries load different
stdc++. Hiding all symbols as local to prevent any conflicts with clients.