### PR TITLE
GDV-125: allow multiple module instances in cache

### DIFF
--- a/cpp/src/codegen/cache.h
+++ b/cpp/src/codegen/cache.h
@@ -41,7 +41,7 @@ class Cache {
 
  private:
   LruCache<KeyType, ValueType> cache_;
-  static const int CACHE_SIZE = 100;
+  static const int CACHE_SIZE = 250;
   std::mutex mtx_;
 };
 }  // namespace gandiva

--- a/cpp/src/codegen/filter_cache_key.h
+++ b/cpp/src/codegen/filter_cache_key.h
@@ -15,6 +15,7 @@
 #ifndef GANDIVA_FILTER_CACHE_KEY_H
 #define GANDIVA_FILTER_CACHE_KEY_H
 
+#include <thread>
 #include "boost/functional/hash.hpp"
 #include "gandiva/arrow.h"
 #include "gandiva/filter.h"
@@ -24,13 +25,15 @@ class FilterCacheKey {
  public:
   FilterCacheKey(SchemaPtr schema, std::shared_ptr<Configuration> configuration,
                  Expression &expression)
-      : schema_(schema), configuration_(configuration) {
+      : schema_(schema), configuration_(configuration), uniqifier_(0) {
     static const int kSeedValue = 4;
     size_t result = kSeedValue;
     expression_as_string_ = expression.ToString();
+    UpdateUniqifier(expression_as_string_);
     boost::hash_combine(result, expression_as_string_);
     boost::hash_combine(result, configuration);
     boost::hash_combine(result, schema_->ToString());
+    boost::hash_combine(result, uniqifier_);
     hash_code_ = result;
   }
 
@@ -47,6 +50,10 @@ class FilterCacheKey {
     }
 
     if (expression_as_string_ != other.expression_as_string_) {
+      return false;
+    }
+
+    if (uniqifier_ != other.uniqifier_) {
       return false;
     }
     return true;
@@ -70,10 +77,19 @@ class FilterCacheKey {
   }
 
  private:
+  void UpdateUniqifier(const std::string expr) {
+    // caching of expressions with re2 patterns causes lock contention. So, use
+    // multiple instances to reduce contention.
+    if (expr.find(" like(") != std::string::npos) {
+      uniqifier_ = std::hash<std::thread::id>()(std::this_thread::get_id()) % 16;
+    }
+  }
+
   const SchemaPtr schema_;
   const std::shared_ptr<Configuration> configuration_;
   std::string expression_as_string_;
   size_t hash_code_;
+  uint32_t uniqifier_;
 };
 }  // namespace gandiva
 #endif  // GANDIVA_FILTER_CACHE_KEY_H

--- a/cpp/src/codegen/projector_cache_key.h
+++ b/cpp/src/codegen/projector_cache_key.h
@@ -16,6 +16,7 @@
 #define GANDIVA_PROJECTOR_CACHE_KEY_H
 
 #include <algorithm>
+#include <thread>
 #include "gandiva/arrow.h"
 #include "gandiva/projector.h"
 
@@ -24,16 +25,17 @@ class ProjectorCacheKey {
  public:
   ProjectorCacheKey(SchemaPtr schema, std::shared_ptr<Configuration> configuration,
                     ExpressionVector expression_vector)
-      : schema_(schema), configuration_(configuration) {
+      : schema_(schema), configuration_(configuration), uniqifier_(0) {
     static const int kSeedValue = 4;
     size_t result = kSeedValue;
     for (auto &expr : expression_vector) {
       std::string expr_as_string = expr->ToString();
       expressions_as_strings_.push_back(expr_as_string);
-      boost::hash_combine(result, expr_as_string);
+      UpdateUniqifier(expr_as_string);
     }
     boost::hash_combine(result, configuration);
     boost::hash_combine(result, schema_->ToString());
+    boost::hash_combine(result, uniqifier_);
     hash_code_ = result;
   }
 
@@ -50,6 +52,10 @@ class ProjectorCacheKey {
     }
 
     if (expressions_as_strings_ != other.expressions_as_strings_) {
+      return false;
+    }
+
+    if (uniqifier_ != other.uniqifier_) {
       return false;
     }
     return true;
@@ -84,10 +90,21 @@ class ProjectorCacheKey {
   }
 
  private:
+  void UpdateUniqifier(const std::string expr) {
+    if (uniqifier_ == 0) {
+      // caching of expressions with re2 patterns causes lock contention. So, use
+      // multiple instances to reduce contention.
+      if (expr.find(" like(") != std::string::npos) {
+        uniqifier_ = std::hash<std::thread::id>()(std::this_thread::get_id()) % 16;
+      }
+    }
+  }
+
   const SchemaPtr schema_;
   const std::shared_ptr<Configuration> configuration_;
   std::vector<std::string> expressions_as_strings_;
   size_t hash_code_;
+  uint32_t uniqifier_;
 };
 }  // namespace gandiva
 #endif  // GANDIVA_PROJECTOR_CACHE_KEY_H

--- a/cpp/src/codegen/projector_cache_key.h
+++ b/cpp/src/codegen/projector_cache_key.h
@@ -31,6 +31,7 @@ class ProjectorCacheKey {
     for (auto &expr : expression_vector) {
       std::string expr_as_string = expr->ToString();
       expressions_as_strings_.push_back(expr_as_string);
+      boost::hash_combine(result, expr_as_string);
       UpdateUniqifier(expr_as_string);
     }
     boost::hash_combine(result, configuration);


### PR DESCRIPTION
- this is a workaround to reduce lock contention for regex exprs