### PR TITLE
Link filter and project operators

### DIFF
--- a/cpp/include/gandiva/projector.h
+++ b/cpp/include/gandiva/projector.h
@@ -74,6 +74,30 @@ class Projector {
   ///                 populated by Evaluate.
   Status Evaluate(const arrow::RecordBatch &batch, const ArrayDataVector &output);
 
+  /// Evaluate the specified record batch, and return the allocated and populated output
+  /// arrays. The output arrays will be allocated from the memory pool 'pool', and added
+  /// to the vector 'output'.
+  ///
+  /// \param[in] : batch the record batch. schema should be the same as the one in 'Make'
+  /// \param[in] : type of selection vector if it is -1 is there then we select all rows
+  /// \param[in] :  selection vector which maintains the filtered row posisitons
+  /// \param[in] : pool memory pool used to allocate output arrays (if required).
+  /// \param[out]: output the vector of allocated/populated arrays.
+  Status Evaluate(const arrow::RecordBatch &batch, const int &mode,
+                  const arrow::Buffer &selection_vector, arrow::MemoryPool *pool,
+                  arrow::ArrayVector *ouput);
+
+  /// Evaluate the specified record batch, and populate the output arrays at the filtered
+  /// positions. The output arrays of sufficient capacity must be allocated by the caller.
+  ///
+  /// \param[in] : batch the record batch. schema should be the same as the one in 'Make'
+  /// \param[in] : type of selection vector if it is -1 is there then we select all rows
+  /// \param[in] :  selection vector which maintains the filtered row posisitons
+  /// \param[in/out]: vector of arrays, the arrays are allocated by the caller and
+  ///                 populated by Evaluate.
+  Status Evaluate(const arrow::RecordBatch &batch, const int &mode,
+                  const arrow::Buffer &selection_vector, const ArrayDataVector &output);
+
  private:
   Projector(std::unique_ptr<LLVMGenerator> llvm_generator, SchemaPtr schema,
             const FieldVector &output_fields, std::shared_ptr<Configuration>);

--- a/cpp/integ/CMakeLists.txt
+++ b/cpp/integ/CMakeLists.txt
@@ -16,6 +16,7 @@ project(gandiva)
 
 foreach(lib_type "shared" "static")
   add_gandiva_integ_test(filter_test.cc gandiva_${lib_type})
+  add_gandiva_integ_test(filter_project_test.cc gandiva_${lib_type})
   add_gandiva_integ_test(projector_test.cc gandiva_${lib_type})
   add_gandiva_integ_test(if_expr_test.cc gandiva_${lib_type})
   add_gandiva_integ_test(literal_test.cc gandiva_${lib_type})

--- a/cpp/integ/filter_project_test.cc
+++ b/cpp/integ/filter_project_test.cc
@@ -1,0 +1,93 @@
+// Copyright (C) 2017-2018 Dremio Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include "arrow/memory_pool.h"
+#include "gandiva/filter.h"
+#include "gandiva/projector.h"
+#include "gandiva/tree_expr_builder.h"
+#include "integ/test_util.h"
+
+namespace gandiva {
+
+using arrow::boolean;
+using arrow::float32;
+using arrow::int32;
+
+class TestFilterProject : public ::testing::Test {
+ public:
+  void SetUp() { pool_ = arrow::default_memory_pool(); }
+
+ protected:
+  arrow::MemoryPool* pool_;
+};
+
+TEST_F(TestFilterProject, TestSimple) {
+  // schema for input fields
+  auto field0 = field("f0", int32());
+  auto field1 = field("f1", int32());
+  auto field2 = field("f2", int32());
+  auto schema = arrow::schema({field0, field1});
+
+  // Build condition f0 < f1
+  auto node_f0 = TreeExprBuilder::MakeField(field0);
+  auto node_f1 = TreeExprBuilder::MakeField(field1);
+  auto less_than_function =
+      TreeExprBuilder::MakeFunction("less_than", {node_f0, node_f1}, arrow::boolean());
+  auto condition = TreeExprBuilder::MakeCondition(less_than_function);
+  auto sum_expr = TreeExprBuilder::MakeExpression("add", {field0, field1}, field2);
+
+  std::shared_ptr<Filter> filter;
+  std::shared_ptr<Projector> projector;
+
+  Status status = Filter::Make(schema, condition, &filter);
+  EXPECT_TRUE(status.ok());
+
+  status = Projector::Make(schema, {sum_expr}, &projector);
+  EXPECT_TRUE(status.ok());
+
+  // Create a row-batch with some sample data
+  int num_records = 5;
+  auto array0 = MakeArrowArrayInt32({1, 2, 6, 40, 3}, {true, true, true, true, true});
+  auto array1 = MakeArrowArrayInt32({5, 9, 3, 17, 6}, {true, true, true, true, true});
+  // expected output
+  auto result = MakeArrowArrayInt32({6, 11, 9}, {true, true, true});
+  // prepare input record batch
+  auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array0, array1});
+
+  std::shared_ptr<SelectionVector> selection_vector;
+  status = SelectionVector::MakeInt16(num_records, pool_, &selection_vector);
+  EXPECT_TRUE(status.ok());
+
+  // Evaluate expression
+  status = filter->Evaluate(*in_batch, selection_vector);
+  EXPECT_TRUE(status.ok());
+
+  // Evaluate expression
+  arrow::ArrayVector outputs;
+  int mode = 0;
+
+  in_batch =
+      arrow::RecordBatch::Make(schema, selection_vector->GetNumSlots(), {array0, array1});
+
+  auto data_buffer = selection_vector->ToArray()->data()->buffers[1];
+  status = projector->Evaluate(*in_batch, mode, *data_buffer, pool_, &outputs);
+  EXPECT_TRUE(status.ok());
+
+  // Validate results
+  EXPECT_ARROW_ARRAY_EQUALS(result, outputs.at(0));
+
+  // Validate results
+}
+}  // namespace gandiva

--- a/cpp/src/codegen/llvm_generator.h
+++ b/cpp/src/codegen/llvm_generator.h
@@ -48,8 +48,17 @@ class LLVMGenerator {
   /// represents an expression tree
   Status Build(const ExpressionVector &exprs);
 
+  /// \brief Build the code for the expression trees for all modes. Each element in the
+  /// vector represents an expression tree
+  Status BuildForAllMode(const ExpressionVector &exprs);
+
   /// \brief Execute the built expression against the provided arguments.
   Status Execute(const arrow::RecordBatch &record_batch,
+                 const ArrayDataVector &output_vector);
+
+  /// \brief Execute the built expression against the provided arguments.
+  Status Execute(const arrow::RecordBatch &record_batch, const int &mode,
+                 const arrow::Buffer &selection_vector,
                  const ArrayDataVector &output_vector);
 
   LLVMTypes &types() { return *types_; }
@@ -129,6 +138,9 @@ class LLVMGenerator {
   // Generate the code for one expression, with the output of the expression going to
   // 'output'.
   Status Add(const ExpressionPtr expr, const FieldDescriptorPtr output);
+  // Generate the code for one expression for all modes, with the output of the expression
+  // going to 'output'.
+  Status AddForAllMode(const ExpressionPtr expr, const FieldDescriptorPtr output);
 
   /// Generate code to load the vector at specified index in the 'arg_addrs' array.
   llvm::Value *LoadVectorAtIndex(llvm::Value *arg_addrs, int idx,
@@ -143,9 +155,13 @@ class LLVMGenerator {
   /// Generate code to load the vector at specified index and cast it as offsets array.
   llvm::Value *GetOffsetsReference(llvm::Value *arg_addrs, int idx, FieldPtr field);
 
-  /// Generate code for the value array of one expression.
+  /// Generate code for the value array of one expression with default mode.
   Status CodeGenExprValue(DexPtr value_expr, FieldDescriptorPtr output, int suffix_idx,
                           llvm::Function **fn);
+
+  /// Generate code for the value array of one expression.
+  Status CodeGenExprValue(DexPtr value_expr, FieldDescriptorPtr output, int suffix_idx,
+                          llvm::Function **fn, int &mode);
 
   /// Generate code to load the local bitmap specified index and cast it as bitmap.
   llvm::Value *GetLocalBitMapReference(llvm::Value *arg_bitmaps, int idx);

--- a/cpp/src/jni/jni_common.cc
+++ b/cpp/src/jni/jni_common.cc
@@ -585,7 +585,8 @@ err_out:
 JNIEXPORT void JNICALL
 Java_org_apache_arrow_gandiva_evaluator_JniWrapper_evaluateProjector(
     JNIEnv *env, jobject cls, jlong module_id, jint num_rows, jlongArray buf_addrs,
-    jlongArray buf_sizes, jlongArray out_buf_addrs, jlongArray out_buf_sizes) {
+    jlongArray buf_sizes, jint sel_vec_type, jlong sel_vec_addr, jlong sel_vec_size,
+    jlongArray out_buf_addrs, jlongArray out_buf_sizes) {
   Status status;
   std::shared_ptr<ProjectorHolder> holder = projector_modules_.Lookup(module_id);
   if (holder == nullptr) {
@@ -646,8 +647,10 @@ Java_org_apache_arrow_gandiva_evaluator_JniWrapper_evaluateProjector(
     if (!status.ok()) {
       break;
     }
-
-    status = holder->projector()->Evaluate(*in_batch, output);
+    auto selection_vector = std::shared_ptr<arrow::Buffer>(
+        new arrow::Buffer(reinterpret_cast<uint8_t *>(sel_vec_addr), sel_vec_size));
+    status =
+        holder->projector()->Evaluate(*in_batch, sel_vec_type, *selection_vector, output);
   } while (0);
 
   env->ReleaseLongArrayElements(buf_addrs, in_buf_addrs, JNI_ABORT);

--- a/java/src/main/java/org/apache/arrow/gandiva/evaluator/JniWrapper.java
+++ b/java/src/main/java/org/apache/arrow/gandiva/evaluator/JniWrapper.java
@@ -158,6 +158,8 @@ class JniWrapper {
    */
   native void evaluateProjector(long moduleId, int numRows,
                                 long[] bufAddrs, long[] bufSizes,
+                                int selectionVectorType,
+                                long selectionVectorAddr, long selectionVectorSize,
                                 long[] outAddrs, long[] outSizes) throws GandivaException;
 
   /**

--- a/java/src/test/java/org/apache/arrow/gandiva/evaluator/FilterProjectTest.java
+++ b/java/src/test/java/org/apache/arrow/gandiva/evaluator/FilterProjectTest.java
@@ -1,0 +1,91 @@
+package org.apache.arrow.gandiva.evaluator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.apache.arrow.gandiva.exceptions.GandivaException;
+import org.apache.arrow.gandiva.expression.Condition;
+import org.apache.arrow.gandiva.expression.ExpressionTree;
+import org.apache.arrow.gandiva.expression.TreeBuilder;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.ValueVector;
+import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
+import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.common.collect.Lists;
+
+import io.netty.buffer.ArrowBuf;
+
+public class FilterProjectTest extends BaseEvaluatorTest {
+
+  @Test
+  public void testSimpleSV16() throws GandivaException, Exception {
+    Field a = Field.nullable("a", int32);
+    Field b = Field.nullable("b", int32);
+    Field c = Field.nullable("c", int32);
+    List<Field> args = Lists.newArrayList(a, b);
+
+    Condition condition = TreeBuilder.makeCondition("less_than", args);
+
+    Schema schema = new Schema(args);
+    Filter filter = Filter.make(schema, condition);
+
+    ExpressionTree expression = TreeBuilder.makeExpression("add", Lists.newArrayList(a, b), c);
+    Projector projector = Projector.make(schema, Lists.newArrayList(expression));
+
+    int numRows = 16;
+    byte[] validity = new byte[]{(byte) 255, 0};
+    // second half is "undefined"
+    int[] values_a = new int[]{1, 2, 3, 4, 5, 6, 7, 8,  9, 10, 11, 12, 13, 14, 15, 16};
+    int[] values_b = new int[]{2, 1, 4, 3, 6, 5, 8, 7, 10,  9, 12, 11, 14, 13, 14, 15};
+    int[] expected = {3, 7, 11, 15};
+
+    verifyTestCaseFor16(filter, projector, numRows, validity, values_a, values_b, expected);
+  }
+
+  private void verifyTestCaseFor16(Filter filter, Projector projector, int numRows, byte[] validity,
+                              int[] values_a, int[] values_b, int[] expected) throws GandivaException {
+    ArrowBuf validitya = buf(validity);
+    ArrowBuf valuesa = intBuf(values_a);
+    ArrowBuf validityb = buf(validity);
+    ArrowBuf valuesb = intBuf(values_b);
+    ArrowRecordBatch batch = new ArrowRecordBatch(
+            numRows,
+            Lists.newArrayList(new ArrowFieldNode(numRows, 0), new ArrowFieldNode(numRows, 0)),
+            Lists.newArrayList(validitya, valuesa, validityb, valuesb));
+
+    ArrowBuf selectionBuffer = buf(numRows * 2);
+    SelectionVectorInt16 selectionVector = new SelectionVectorInt16(selectionBuffer);
+
+    filter.evaluate(batch, selectionVector);
+
+    IntVector intVector = new IntVector(EMPTY_SCHEMA_PATH, allocator);
+    intVector.allocateNew(selectionVector.getRecordCount());
+
+    List<ValueVector> output = new ArrayList<ValueVector>();
+    output.add(intVector);
+    projector.evaluate(batch, selectionVector, output);
+
+    for (int i = 0; i < 4; i++) {
+      assertFalse(intVector.isNull(i));
+      assertEquals(expected[i], intVector.get(i));
+    }
+
+    // free buffers
+    releaseRecordBatch(batch);
+    releaseValueVectors(output);
+    selectionBuffer.close();
+    filter.close();
+    projector.close();
+  }
+}


### PR DESCRIPTION
This patch enables gandiva to link filter node to a project operator. We will be sending the selection vector populated from the filter to a project node so the project operation is performed only on the filtered positions.