### PR TITLE
Add support to SHA256 hash as native function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ install_manifest.txt
 cmake-build-debug
 build
 .idea
+.vscode

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -8,13 +8,19 @@ out-of-source builds only.
 Build Gandiva requires:
 
 * A C++11-enabled compiler. On Linux, gcc 4.8 and higher should be sufficient.
-* CMake
+* CMake(3.11+)
 * LLVM
-* Arrow
+* Arrow(0.10.0)
 * Boost
-* Protobuf
+* Protobuf(3.6.0+)
 * re2
 * OpenSSL
+
+Possible dependencies problems:  
+- **fPIC**: The already compiled binaries for the `re2` and `protobuf` libraries inside the
+  linux distributions packages can lead to errors during compile time, with a message warning
+  about the `fPIC` flag. To solve these problems, download the projects sources and compile
+  them using the defined flag.
 
 On macOS, you can use [Homebrew][1]:
 

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -14,11 +14,12 @@ Build Gandiva requires:
 * Boost
 * Protobuf
 * re2
+* OpenSSL
 
 On macOS, you can use [Homebrew][1]:
 
 ```shell
-brew install cmake llvm boost protobuf re2
+brew install cmake llvm boost protobuf re2 openssl
 ```
 
 To install arrow, follow the steps in the [arrow Readme][2].

--- a/cpp/cmake/BuildUtils.cmake
+++ b/cpp/cmake/BuildUtils.cmake
@@ -82,7 +82,7 @@ function(add_precompiled_unit_test REL_TEST_NAME)
 
   add_executable(${TEST_NAME} ${REL_TEST_NAME} ${ARGN})
   target_include_directories(${TEST_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/src)
-  target_link_libraries(${TEST_NAME} PRIVATE RE2::RE2_STATIC gtest_main)
+  target_link_libraries(${TEST_NAME} PRIVATE RE2::RE2_STATIC gtest_main ssl crypto)
   target_compile_definitions(${TEST_NAME} PRIVATE GANDIVA_UNIT_TEST=1)
   target_compile_definitions(${TEST_NAME} PRIVATE -DGDV_HELPERS)
   add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})

--- a/cpp/src/codegen/function_registry.cc
+++ b/cpp/src/codegen/function_registry.cc
@@ -154,6 +154,10 @@ using std::vector;
   NativeFunction(#NAME, DataTypeVector{TYPE(), int64()}, int64(), RESULT_NULL_NEVER, \
                  STRINGIFY(NAME##WithSeed_##TYPE))
 
+#define HASH_SHA_256_SAFE_NULL_NEVER(NAME, TYPE)                                      \
+  NativeFunction(#NAME, DataTypeVector{TYPE()}, utf8(), RESULT_NULL_NEVER, \
+                 STRINGIFY(NAME##WithSeed_##TYPE))
+
 // Iterate the inner macro over all numeric types
 #define NUMERIC_TYPES(INNER, NAME)                                                       \
   INNER(NAME, int8), INNER(NAME, int16), INNER(NAME, int32), INNER(NAME, int64),         \
@@ -392,6 +396,8 @@ NativeFunction FunctionRegistry::pc_registry_[] = {
     NUMERIC_BOOL_DATE_VAR_LEN_TYPES(HASH64_SAFE_NULL_NEVER, hash64AsDouble),
     NUMERIC_BOOL_DATE_VAR_LEN_TYPES(HASH64_SEED_SAFE_NULL_NEVER, hash64),
     NUMERIC_BOOL_DATE_VAR_LEN_TYPES(HASH64_SEED_SAFE_NULL_NEVER, hash64AsDouble),
+
+    NUMERIC_BOOL_DATE_VAR_LEN_TYPES(HASH_SHA_256_SAFE_NULL_NEVER, hashSha256),
 
     // utf8/binary operations
     UNARY_SAFE_NULL_IF_NULL(octet_length, utf8, int32),

--- a/cpp/src/precompiled/CMakeLists.txt
+++ b/cpp/src/precompiled/CMakeLists.txt
@@ -14,6 +14,14 @@
 
 project(gandiva)
 
+find_package(OpenSSL REQUIRED)
+
+if (OPENSSL_FOUND)
+  message(STATUS "Found OpenSSL library in ${OPENSSL_VERSION} version.")
+else(OPENSSL_FOUND)
+  message(FATAL_ERROR "Could not find the OpenSSL library.")
+endif(OPENSSL_FOUND)
+
 set(PRECOMPILED_SRCS
     arithmetic_ops.cc
     bitmap.cc

--- a/cpp/src/precompiled/CMakeLists.txt
+++ b/cpp/src/precompiled/CMakeLists.txt
@@ -18,6 +18,9 @@ find_package(OpenSSL REQUIRED)
 
 if (OPENSSL_FOUND)
   message(STATUS "Found OpenSSL library with ${OPENSSL_VERSION} version.")
+  message(STATUS "Found the OpenSSL ssl library in ${OPENSSL_SSL_LIBRARY}.")
+  message(STATUS "Found the OpenSSL crypto library in ${OPENSSL_CRYPTO_LIBRARY}.")
+  message(STATUS "Found the OpenSSL include directory  in ${OPENSSL_INCLUDE_DIR}.")
 else(OPENSSL_FOUND)
   message(FATAL_ERROR "Could not find the OpenSSL library.")
 endif(OPENSSL_FOUND)
@@ -27,12 +30,14 @@ set(PRECOMPILED_SRCS
     bitmap.cc
     context_helper.cc
     extended_math_ops.cc
-    hash.cc
     print.cc
     sample.cc
     string_ops.cc
     time.cc
     timestamp_arithmetic.cc)
+
+set(PRECOMPILED_SRCS_OPENSSL_DEPENDENCIES
+    hash.cc)
 
 # Create bitcode for each of the source files.
 foreach(SRC_FILE ${PRECOMPILED_SRCS})
@@ -43,6 +48,19 @@ foreach(SRC_FILE ${PRECOMPILED_SRCS})
     OUTPUT ${BC_FILE}
     COMMAND ${CLANG_EXECUTABLE}
             -D GDV_HELPERS -std=c++11 -emit-llvm -O2 -c ${ABSOLUTE_SRC} -o ${BC_FILE}
+    DEPENDS ${SRC_FILE})
+  list(APPEND BC_FILES ${BC_FILE})
+endforeach()
+
+# Create bitcode for each of the source files with OpenSSL dependencies.
+foreach(SRC_FILE ${PRECOMPILED_SRCS_OPENSSL_DEPENDENCIES})
+  get_filename_component(SRC_BASE ${SRC_FILE} NAME_WE)
+  get_filename_component(ABSOLUTE_SRC ${SRC_FILE} ABSOLUTE)
+  set(BC_FILE ${CMAKE_CURRENT_BINARY_DIR}/${SRC_BASE}.bc)
+  add_custom_command(
+    OUTPUT ${BC_FILE}
+    COMMAND ${CLANG_EXECUTABLE}
+            -D GDV_HELPERS -std=c++11 -emit-llvm -O2 -L${OPENSSL_INCLUDE_DIR} -lssl -lcrypto -c ${ABSOLUTE_SRC} -o ${BC_FILE}
     DEPENDS ${SRC_FILE})
   list(APPEND BC_FILES ${BC_FILE})
 endforeach()

--- a/cpp/src/precompiled/CMakeLists.txt
+++ b/cpp/src/precompiled/CMakeLists.txt
@@ -17,7 +17,7 @@ project(gandiva)
 find_package(OpenSSL REQUIRED)
 
 if (OPENSSL_FOUND)
-  message(STATUS "Found OpenSSL library in ${OPENSSL_VERSION} version.")
+  message(STATUS "Found OpenSSL library with ${OPENSSL_VERSION} version.")
 else(OPENSSL_FOUND)
   message(FATAL_ERROR "Could not find the OpenSSL library.")
 endif(OPENSSL_FOUND)

--- a/cpp/src/precompiled/hash.cc
+++ b/cpp/src/precompiled/hash.cc
@@ -278,12 +278,12 @@ VAR_LEN_TYPES(HASH64_BUF_OP, hash64AsDouble)
 VAR_LEN_TYPES(HASH64_BUF_WITH_SEED_OP, hash64WithSeed)
 VAR_LEN_TYPES(HASH64_BUF_WITH_SEED_OP, hash64AsDoubleWithSeed)
 
-static inline utf8 hash_using_SHA256(void* message) {
+static inline utf8 hash_using_SHA256(const void* message, const size_t message_length) {
   EVP_MD_CTX *md_ctx = EVP_MD_CTX_new();
 
-  EVP_DigestInit_ex(md_ctx, EVP_sha256(), nullptr);
+  EVP_DigestInit_ex(md_ctx, EVP_sha256(), NULL);
 
-  EVP_DigestUpdate(md_ctx, message, sizeof(message));
+  EVP_DigestUpdate(md_ctx, message, message_length);
 
   int sha256_hash_size = EVP_MD_size(EVP_sha256());
 
@@ -295,7 +295,22 @@ static inline utf8 hash_using_SHA256(void* message) {
 
   EVP_MD_CTX_free(md_ctx);
 
-  return (char*) result;
+  char* hex_buffer = new char[4];
+  char* result_buffer = new char[65];
+
+  for (int j = 0; j < result_length; j++) {
+    unsigned char hex_number = result[j];
+    sprintf(hex_buffer, "%02x", hex_number);
+
+    strcat(result_buffer, hex_buffer);
+  }
+
+  result_buffer[64] = '\0';
+
+  free(hex_buffer);
+  free(result);
+
+  return result_buffer;
 }
 
 #define HASH_SHA256_OP(NAME, TYPE)                                     \

--- a/cpp/src/precompiled/hash.cc
+++ b/cpp/src/precompiled/hash.cc
@@ -278,10 +278,14 @@ VAR_LEN_TYPES(HASH64_BUF_OP, hash64AsDouble)
 VAR_LEN_TYPES(HASH64_BUF_WITH_SEED_OP, hash64WithSeed)
 VAR_LEN_TYPES(HASH64_BUF_WITH_SEED_OP, hash64AsDoubleWithSeed)
 
+static inline void clean_char_array(char *buffer) {
+  buffer[0] = '\0';
+}
+
 static inline utf8 hash_using_SHA256(const void* message, const size_t message_length) {
   EVP_MD_CTX *md_ctx = EVP_MD_CTX_new();
 
-  EVP_DigestInit_ex(md_ctx, EVP_sha256(), NULL);
+  EVP_DigestInit_ex(md_ctx, EVP_sha256(), nullptr);
 
   EVP_DigestUpdate(md_ctx, message, message_length);
 
@@ -297,6 +301,9 @@ static inline utf8 hash_using_SHA256(const void* message, const size_t message_l
 
   char* hex_buffer = new char[4];
   char* result_buffer = new char[65];
+
+  clean_char_array(hex_buffer);
+  clean_char_array(result_buffer);
 
   for (unsigned int j = 0; j < result_length; j++) {
     unsigned char hex_number = result[j];

--- a/cpp/src/precompiled/hash.cc
+++ b/cpp/src/precompiled/hash.cc
@@ -14,8 +14,9 @@
 
 extern "C" {
 
-#include <string.h>
+#include <cstring>
 #include "./types.h"
+#include "openssl/evp.h"
 
 static inline uint64 rotate_left(uint64 val, int distance) {
   return (val << distance) | (val >> (64 - distance));
@@ -276,5 +277,25 @@ VAR_LEN_TYPES(HASH64_BUF_OP, hash64)
 VAR_LEN_TYPES(HASH64_BUF_OP, hash64AsDouble)
 VAR_LEN_TYPES(HASH64_BUF_WITH_SEED_OP, hash64WithSeed)
 VAR_LEN_TYPES(HASH64_BUF_WITH_SEED_OP, hash64AsDoubleWithSeed)
+
+static inline utf8 hashSHA256(char* message) {
+  EVP_MD_CTX *md_ctx = EVP_MD_CTX_new();
+
+  EVP_DigestInit_ex(md_ctx, EVP_sha256(), NULL);
+
+  EVP_DigestUpdate(md_ctx, message, strlen(message));
+
+  int sha256_hash_size = EVP_MD_size(EVP_sha256());
+
+  auto* result = (unsigned char*) OPENSSL_malloc(sha256_hash_size);
+
+  unsigned int result_length;
+
+  EVP_DigestFinal_ex(md_ctx, result, &result_length);
+
+  EVP_MD_CTX_free(md_ctx);
+
+  return (char*) result;
+}
 
 }  // extern "C"

--- a/cpp/src/precompiled/hash.cc
+++ b/cpp/src/precompiled/hash.cc
@@ -278,7 +278,7 @@ VAR_LEN_TYPES(HASH64_BUF_OP, hash64AsDouble)
 VAR_LEN_TYPES(HASH64_BUF_WITH_SEED_OP, hash64WithSeed)
 VAR_LEN_TYPES(HASH64_BUF_WITH_SEED_OP, hash64AsDoubleWithSeed)
 
-static inline utf8 hash_using_SHA256(const void* message, const size_t message_length) {
+FORCE_INLINE static inline utf8 hash_using_SHA256(const void* message, const size_t message_length) {
   EVP_MD_CTX *md_ctx = EVP_MD_CTX_new();
 
   EVP_DigestInit_ex(md_ctx, EVP_sha256(), NULL);

--- a/cpp/src/precompiled/hash.cc
+++ b/cpp/src/precompiled/hash.cc
@@ -278,7 +278,7 @@ VAR_LEN_TYPES(HASH64_BUF_OP, hash64AsDouble)
 VAR_LEN_TYPES(HASH64_BUF_WITH_SEED_OP, hash64WithSeed)
 VAR_LEN_TYPES(HASH64_BUF_WITH_SEED_OP, hash64AsDoubleWithSeed)
 
-static inline utf8 hashSHA256(void* message) {
+static inline utf8 hash_using_SHA256(void* message) {
   EVP_MD_CTX *md_ctx = EVP_MD_CTX_new();
 
   EVP_DigestInit_ex(md_ctx, EVP_sha256(), nullptr);
@@ -297,5 +297,22 @@ static inline utf8 hashSHA256(void* message) {
 
   return (char*) result;
 }
+
+#define HASH_SHA256_OP(NAME, TYPE)                                     \
+  FORCE_INLINE                                                         \
+  utf8 NAME##_##TYPE(TYPE value, boolean is_valid) {                   \
+    long value_as_long = double_to_long_bits((double) value);          \
+    return is_valid ? hash_using_SHA256(&value_as_long) : (char *) ""; \
+  }
+
+NUMERIC_BOOL_DATE_TYPES(HASH_SHA256_OP, hashSHA256)
+
+#define HASH_SHA256_BUF_OP(NAME, TYPE)                        \
+  FORCE_INLINE                                                \
+  utf8 NAME##_##TYPE(TYPE value, boolean is_valid) {          \
+    return is_valid ? hash_using_SHA256(value) : (char *) ""; \
+  }
+
+VAR_LEN_TYPES(HASH_SHA256_BUF_OP, hashSHA256)
 
 }  // extern "C"

--- a/cpp/src/precompiled/hash.cc
+++ b/cpp/src/precompiled/hash.cc
@@ -318,6 +318,10 @@ FORCE_INLINE utf8 hash_sha256(double value, boolean is_valid){
   return is_valid ? hash_using_SHA256(&value_as_long, sizeof(value_as_long)) : (char *) "";
 }
 
+FORCE_INLINE utf8 hash_sha256_buf_op(char* value, boolean is_valid){
+  return is_valid ? hash_using_SHA256(value, strlen(value)) : (char *) "";
+}
+
 #define HASH_SHA256_OP(NAME, TYPE)                                                            \
   FORCE_INLINE                                                                                \
   utf8 NAME##_##TYPE(TYPE value, boolean is_valid) {                                          \

--- a/cpp/src/precompiled/hash.cc
+++ b/cpp/src/precompiled/hash.cc
@@ -325,7 +325,7 @@ FORCE_INLINE utf8 hash_sha256(double value) {
   return hash_using_SHA256(&value_as_long, sizeof(value_as_long));
 }
 
-FORCE_INLINE utf8 hash_sha256_buf_op(char* value) {
+FORCE_INLINE utf8 hash_sha256_buf_op(const char* value) {
   return hash_using_SHA256(value, strlen(value));
 }
 

--- a/cpp/src/precompiled/hash.cc
+++ b/cpp/src/precompiled/hash.cc
@@ -313,28 +313,27 @@ static inline utf8 hash_using_SHA256(const void* message, const size_t message_l
   return result_buffer;
 }
 
-FORCE_INLINE utf8 hash_sha256(double value, boolean is_valid){
+FORCE_INLINE utf8 hash_sha256(double value){
   long value_as_long = double_to_long_bits(value);
-  return is_valid ? hash_using_SHA256(&value_as_long, sizeof(value_as_long)) : (char *) "";
+  return hash_using_SHA256(&value_as_long, sizeof(value_as_long));
 }
 
-FORCE_INLINE utf8 hash_sha256_buf_op(char* value, boolean is_valid){
-  return is_valid ? hash_using_SHA256(value, strlen(value)) : (char *) "";
+FORCE_INLINE utf8 hash_sha256_buf_op(char* value){
+  return hash_using_SHA256(value, strlen(value));
 }
 
-#define HASH_SHA256_OP(NAME, TYPE)                                                            \
-  FORCE_INLINE                                                                                \
-  utf8 NAME##_##TYPE(TYPE value, boolean is_valid) {                                          \
-    long value_as_long = double_to_long_bits((double) value);                                 \
-    return is_valid ? hash_using_SHA256(&value_as_long, sizeof(value_as_long)) : (char *) ""; \
+#define HASH_SHA256_OP(NAME, TYPE)                              \
+  FORCE_INLINE                                                  \
+  utf8 NAME##_##TYPE(TYPE value, boolean is_valid) {            \
+    return is_valid ? hash_sha256(value) : (char *) ""; \
   }
 
 NUMERIC_BOOL_DATE_TYPES(HASH_SHA256_OP, hashSHA256)
 
-#define HASH_SHA256_BUF_OP(NAME, TYPE)                                       \
-  FORCE_INLINE                                                               \
-  utf8 NAME##_##TYPE(TYPE value, boolean is_valid) {                         \
-    return is_valid ? hash_using_SHA256(value, strlen(value)) : (char *) ""; \
+#define HASH_SHA256_BUF_OP(NAME, TYPE)                         \
+  FORCE_INLINE                                                 \
+  utf8 NAME##_##TYPE(TYPE value, boolean is_valid) {           \
+    return is_valid ? hash_sha256_buf_op(value) : (char *) ""; \
   }
 
 VAR_LEN_TYPES(HASH_SHA256_BUF_OP, hashSHA256)

--- a/cpp/src/precompiled/hash.cc
+++ b/cpp/src/precompiled/hash.cc
@@ -313,19 +313,19 @@ static inline utf8 hash_using_SHA256(const void* message, const size_t message_l
   return result_buffer;
 }
 
-#define HASH_SHA256_OP(NAME, TYPE)                                     \
-  FORCE_INLINE                                                         \
-  utf8 NAME##_##TYPE(TYPE value, boolean is_valid) {                   \
-    long value_as_long = double_to_long_bits((double) value);          \
-    return is_valid ? hash_using_SHA256(&value_as_long) : (char *) ""; \
+#define HASH_SHA256_OP(NAME, TYPE)                                                            \
+  FORCE_INLINE                                                                                \
+  utf8 NAME##_##TYPE(TYPE value, boolean is_valid) {                                          \
+    long value_as_long = double_to_long_bits((double) value);                                 \
+    return is_valid ? hash_using_SHA256(&value_as_long, sizeof(value_as_long)) : (char *) ""; \
   }
 
 NUMERIC_BOOL_DATE_TYPES(HASH_SHA256_OP, hashSHA256)
 
-#define HASH_SHA256_BUF_OP(NAME, TYPE)                        \
-  FORCE_INLINE                                                \
-  utf8 NAME##_##TYPE(TYPE value, boolean is_valid) {          \
-    return is_valid ? hash_using_SHA256(value) : (char *) ""; \
+#define HASH_SHA256_BUF_OP(NAME, TYPE)                                       \
+  FORCE_INLINE                                                               \
+  utf8 NAME##_##TYPE(TYPE value, boolean is_valid) {                         \
+    return is_valid ? hash_using_SHA256(value, strlen(value)) : (char *) ""; \
   }
 
 VAR_LEN_TYPES(HASH_SHA256_BUF_OP, hashSHA256)

--- a/cpp/src/precompiled/hash.cc
+++ b/cpp/src/precompiled/hash.cc
@@ -278,7 +278,7 @@ VAR_LEN_TYPES(HASH64_BUF_OP, hash64AsDouble)
 VAR_LEN_TYPES(HASH64_BUF_WITH_SEED_OP, hash64WithSeed)
 VAR_LEN_TYPES(HASH64_BUF_WITH_SEED_OP, hash64AsDoubleWithSeed)
 
-FORCE_INLINE static inline utf8 hash_using_SHA256(const void* message, const size_t message_length) {
+static inline utf8 hash_using_SHA256(const void* message, const size_t message_length) {
   EVP_MD_CTX *md_ctx = EVP_MD_CTX_new();
 
   EVP_DigestInit_ex(md_ctx, EVP_sha256(), NULL);
@@ -311,6 +311,11 @@ FORCE_INLINE static inline utf8 hash_using_SHA256(const void* message, const siz
   free(result);
 
   return result_buffer;
+}
+
+FORCE_INLINE utf8 hash_sha256(double value, boolean is_valid){
+  long value_as_long = double_to_long_bits(value);
+  return is_valid ? hash_using_SHA256(&value_as_long, sizeof(value_as_long)) : (char *) "";
 }
 
 #define HASH_SHA256_OP(NAME, TYPE)                                                            \

--- a/cpp/src/precompiled/hash.cc
+++ b/cpp/src/precompiled/hash.cc
@@ -298,7 +298,7 @@ static inline utf8 hash_using_SHA256(const void* message, const size_t message_l
   char* hex_buffer = new char[4];
   char* result_buffer = new char[65];
 
-  for (int j = 0; j < result_length; j++) {
+  for (unsigned int j = 0; j < result_length; j++) {
     unsigned char hex_number = result[j];
     sprintf(hex_buffer, "%02x", hex_number);
 

--- a/cpp/src/precompiled/hash.cc
+++ b/cpp/src/precompiled/hash.cc
@@ -278,12 +278,12 @@ VAR_LEN_TYPES(HASH64_BUF_OP, hash64AsDouble)
 VAR_LEN_TYPES(HASH64_BUF_WITH_SEED_OP, hash64WithSeed)
 VAR_LEN_TYPES(HASH64_BUF_WITH_SEED_OP, hash64AsDoubleWithSeed)
 
-static inline utf8 hashSHA256(char* message) {
+static inline utf8 hashSHA256(void* message) {
   EVP_MD_CTX *md_ctx = EVP_MD_CTX_new();
 
-  EVP_DigestInit_ex(md_ctx, EVP_sha256(), NULL);
+  EVP_DigestInit_ex(md_ctx, EVP_sha256(), nullptr);
 
-  EVP_DigestUpdate(md_ctx, message, strlen(message));
+  EVP_DigestUpdate(md_ctx, message, sizeof(message));
 
   int sha256_hash_size = EVP_MD_size(EVP_sha256());
 

--- a/cpp/src/precompiled/hash.cc
+++ b/cpp/src/precompiled/hash.cc
@@ -14,7 +14,7 @@
 
 extern "C" {
 
-#include <cstring>
+#include <string.h>
 #include "./types.h"
 #include "openssl/evp.h"
 

--- a/cpp/src/precompiled/hash.cc
+++ b/cpp/src/precompiled/hash.cc
@@ -313,12 +313,12 @@ static inline utf8 hash_using_SHA256(const void* message, const size_t message_l
   return result_buffer;
 }
 
-FORCE_INLINE utf8 hash_sha256(double value){
+FORCE_INLINE utf8 hash_sha256(double value) {
   long value_as_long = double_to_long_bits(value);
   return hash_using_SHA256(&value_as_long, sizeof(value_as_long));
 }
 
-FORCE_INLINE utf8 hash_sha256_buf_op(char* value){
+FORCE_INLINE utf8 hash_sha256_buf_op(char* value) {
   return hash_using_SHA256(value, strlen(value));
 }
 

--- a/cpp/src/precompiled/hash.cc
+++ b/cpp/src/precompiled/hash.cc
@@ -278,6 +278,10 @@ VAR_LEN_TYPES(HASH64_BUF_OP, hash64AsDouble)
 VAR_LEN_TYPES(HASH64_BUF_WITH_SEED_OP, hash64WithSeed)
 VAR_LEN_TYPES(HASH64_BUF_WITH_SEED_OP, hash64AsDoubleWithSeed)
 
+/*
+ * Sets a char pointer as an empty string. It is used because when a char array is created
+ * it can contains some garbage values.
+ * */
 static inline void clean_char_array(char *buffer) {
   buffer[0] = '\0';
 }

--- a/cpp/src/precompiled/hash.cc
+++ b/cpp/src/precompiled/hash.cc
@@ -286,6 +286,17 @@ static inline void clean_char_array(char *buffer) {
   buffer[0] = '\0';
 }
 
+/*
+ * Hashes a generic message and return a SHA256 string using the OpenSSL EVP module. For more information
+ * see the main docs in https://www.openssl.org/docs/manmaster/man3/EVP_DigestInit.html.
+ *
+ * For example:
+ * - inputs:
+ *    - message: "hello world!"
+ *    - message_length: 12
+ * - output:
+ *    - "7509e5bda0c762d2bac7f90d758b5b2263fa01ccbc542ab5e3df163be08e6ca9"
+ * */
 static inline utf8 hash_using_SHA256(const void* message, const size_t message_length) {
   EVP_MD_CTX *md_ctx = EVP_MD_CTX_new();
 
@@ -300,8 +311,6 @@ static inline utf8 hash_using_SHA256(const void* message, const size_t message_l
   unsigned int result_length;
 
   EVP_DigestFinal_ex(md_ctx, result, &result_length);
-
-  EVP_MD_CTX_free(md_ctx);
 
   char* hex_buffer = new char[4];
   char* result_buffer = new char[65];
@@ -318,6 +327,8 @@ static inline utf8 hash_using_SHA256(const void* message, const size_t message_l
 
   result_buffer[64] = '\0';
 
+  // free the resources to avoid memory leaks
+  EVP_MD_CTX_free(md_ctx);
   free(hex_buffer);
   free(result);
 

--- a/cpp/src/precompiled/hash_test.cc
+++ b/cpp/src/precompiled/hash_test.cc
@@ -116,4 +116,32 @@ TEST(TestHash, TestHashBuf) {
             hash64_buf((const uint8 *)buf, buf_len, 1));
 }
 
+TEST(TestHash, TestHashSha256) {
+  int8 s8 = 0;
+  uint8 u8 = 0;
+  int16 s16 = 0;
+  uint16 u16 = 0;
+  int32 s32 = 0;
+  uint32 u32 = 0;
+  int64 s64 = 0;
+  uint64 u64 = 0;
+  float32 f32 = 0;
+  float64 f64 = 0;
+
+  // hash of 0 should be non-zero (zero is the hash value for nulls).
+  utf8 zero_hash = hash_sha256(s8);
+  EXPECT_NE(zero_hash, "");
+
+  // for a given value, all numeric types must have the same hash.
+  EXPECT_STREQ(hash_sha256(u8), zero_hash);
+  EXPECT_STREQ(hash_sha256(s16), zero_hash);
+  EXPECT_STREQ(hash_sha256(u16), zero_hash);
+  EXPECT_STREQ(hash_sha256(s32), zero_hash);
+  EXPECT_STREQ(hash_sha256(u32), zero_hash);
+  EXPECT_STREQ(hash_sha256(s64), zero_hash);
+  EXPECT_STREQ(hash_sha256(u64), zero_hash);
+  EXPECT_STREQ(hash_sha256(f32), zero_hash);
+  EXPECT_STREQ(hash_sha256(f64), zero_hash);
+}
+
 }  // namespace gandiva

--- a/cpp/src/precompiled/hash_test.cc
+++ b/cpp/src/precompiled/hash_test.cc
@@ -144,4 +144,14 @@ TEST(TestHash, TestHashSha256) {
   EXPECT_STREQ(hash_sha256(f64), zero_hash);
 }
 
+TEST(TestHash, TestHashSha256Buf) {
+  const char *buf = "hello";
+
+  EXPECT_STRNE(hash_sha256_buf_op(buf), "");
+
+  const char *modified_buf = "hEllo";
+
+  EXPECT_STRNE(hash_sha256_buf_op(buf), hash_sha256_buf_op(modified_buf));
+}
+
 }  // namespace gandiva

--- a/cpp/src/precompiled/types.h
+++ b/cpp/src/precompiled/types.h
@@ -16,6 +16,7 @@
 #define PRECOMPILED_TYPES_H
 
 #include <stdint.h>
+#include <cstdlib>
 
 // Use the same names as in arrow data types. Makes it easy to write pre-processor macros.
 using boolean = bool;
@@ -72,6 +73,7 @@ int32 hash32(double val, int32 seed);
 int32 hash32_buf(const uint8 *buf, int len, int32 seed);
 int64 hash64(double val, int64 seed);
 int64 hash64_buf(const uint8 *buf, int len, int64 seed);
+utf8 hash_using_SHA256(const void* message, const size_t message_length);
 
 int64 timestampaddSecond_timestamp_int32(timestamp, int32);
 int64 timestampaddMinute_timestamp_int32(timestamp, int32);

--- a/cpp/src/precompiled/types.h
+++ b/cpp/src/precompiled/types.h
@@ -73,7 +73,7 @@ int32 hash32_buf(const uint8 *buf, int len, int32 seed);
 int64 hash64(double val, int64 seed);
 int64 hash64_buf(const uint8 *buf, int len, int64 seed);
 utf8 hash_sha256(double value);
-utf8 hash_sha256_buf_op(char* value);
+utf8 hash_sha256_buf_op(const char* value);
 
 int64 timestampaddSecond_timestamp_int32(timestamp, int32);
 int64 timestampaddMinute_timestamp_int32(timestamp, int32);

--- a/cpp/src/precompiled/types.h
+++ b/cpp/src/precompiled/types.h
@@ -16,7 +16,6 @@
 #define PRECOMPILED_TYPES_H
 
 #include <stdint.h>
-#include <cstdlib>
 
 // Use the same names as in arrow data types. Makes it easy to write pre-processor macros.
 using boolean = bool;
@@ -73,7 +72,8 @@ int32 hash32(double val, int32 seed);
 int32 hash32_buf(const uint8 *buf, int len, int32 seed);
 int64 hash64(double val, int64 seed);
 int64 hash64_buf(const uint8 *buf, int len, int64 seed);
-utf8 hash_using_SHA256(const void* message, const size_t message_length);
+utf8 hash_sha256(double value);
+utf8 hash_sha256_buf_op(char* value);
 
 int64 timestampaddSecond_timestamp_int32(timestamp, int32);
 int64 timestampaddMinute_timestamp_int32(timestamp, int32);


### PR DESCRIPTION
This PR adds three native functions to add supports to SHA256 hash. The SHA256 is a cryptographic hash function that generates a 64-digit string that represents a hexadecimal number, for example `7509e5bda0c762d2bac7f90d758b5b2263fa01ccbc542ab5e3df163be08e6ca9`.

The methods added to the project are:
   - **hashSha256AsString**: gets a generic value and returns a 64-digit string with the complete hash result.
 
To generate the hash, it was used the [EVP module of the OpenSSL library](https://www.openssl.org/docs/manmaster/man3/EVP_DigestInit.html).